### PR TITLE
adding scripts to run code coverage and push to sonar

### DIFF
--- a/prime-angular-frontend/package.json
+++ b/prime-angular-frontend/package.json
@@ -7,7 +7,9 @@
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",
-    "e2e": "ng e2e"
+    "e2e": "ng e2e",
+    "coverage": "ng test --watch=false --code-coverage --browsers=ChromeHeadless",
+    "sonar": "npm run coverage && sonar-scanner"
   },
   "private": true,
   "dependencies": {
@@ -54,7 +56,9 @@
     "karma-coverage-istanbul-reporter": "~2.0.1",
     "karma-jasmine": "~2.0.1",
     "karma-jasmine-html-reporter": "^1.4.0",
+    "puppeteer": "~2.0.0",
     "protractor": "~5.4.0",
+    "sonar-scanner": "~3.1.0",
     "ts-node": "~7.0.0",
     "tslint": "~5.15.0",
     "typescript": "~3.5.3"

--- a/prime-angular-frontend/package.json
+++ b/prime-angular-frontend/package.json
@@ -56,7 +56,6 @@
     "karma-coverage-istanbul-reporter": "~2.0.1",
     "karma-jasmine": "~2.0.1",
     "karma-jasmine-html-reporter": "^1.4.0",
-    "puppeteer": "~2.0.0",
     "protractor": "~5.4.0",
     "sonar-scanner": "~3.1.0",
     "ts-node": "~7.0.0",

--- a/prime-angular-frontend/sonar-project.properties
+++ b/prime-angular-frontend/sonar-project.properties
@@ -1,0 +1,13 @@
+#sonar.host.url=http://sonar-backend-dqszvc-tools.pathfinder.gov.bc.ca
+sonar.host.url=http://localhost:9000
+#sonar.login=admin
+#sonar.password=admin
+sonar.projectKey=prime-angular-frontend
+sonar.projectName=prime-angular-frontend
+sonar.projectVersion=1.0
+sonar.sourceEncoding=UTF-8
+sonar.sources=src
+sonar.exclusions=**/node_modules/**
+sonar.tests=src
+sonar.test.inclusions=**/*.spec.ts
+sonar.typescript.lcov.reportPaths=coverage/angular-frontend/lcov.info


### PR DESCRIPTION
To run this - just call 'npm run sonar' and it will run the 'ng test' and create code coverage files, and then run the sonar scanner to push to sonar.  Config which sonar instance to send to in the sonar-project.properties file.  It also includes puppeteer which allows the tests to run headless.