### PR TITLE
Refactoring and cleanup of enrollee controller + service

### DIFF
--- a/prime-dotnet-webapi-tests/Controllers/EnrolleesController.Tests.cs
+++ b/prime-dotnet-webapi-tests/Controllers/EnrolleesController.Tests.cs
@@ -167,7 +167,7 @@ namespace PrimeTests.Controllers
                 Assert.Equal(EnrolleeServiceMock.DEFAULT_ENROLLEES_SIZE, enrollees.Count());
 
                 // get an enrollee id that does not exist
-                int notFoundEnrolleeId = EnrolleeServiceMock.MAX_ENROLLEE_ID + 1;
+                int notFoundEnrolleeId = enrollees.Max(e => e.Id.Value) + 1;
 
                 // create a request with an AUTH token
                 var request = TestUtils.CreateRequest(HttpMethod.Get, $"/api/enrollees/{notFoundEnrolleeId}", Guid.NewGuid());
@@ -259,7 +259,7 @@ namespace PrimeTests.Controllers
                 var testEnrollee = TestUtils.EnrolleeFaker.Generate();
 
                 // create a request with an AUTH token
-                var request = TestUtils.CreateRequest(HttpMethod.Post, "/api/enrollees", Guid.NewGuid(), testEnrollee);
+                var request = TestUtils.CreateRequest(HttpMethod.Post, "/api/enrollees", testEnrollee.UserId, testEnrollee);
 
                 // try to create the enrollee
                 var response = await _client.SendAsync(request);
@@ -381,7 +381,7 @@ namespace PrimeTests.Controllers
                 Assert.Equal(EnrolleeServiceMock.DEFAULT_ENROLLEES_SIZE, enrollees.Count());
 
                 // get an enrollee id that does not exist
-                int notFoundEnrolleeId = EnrolleeServiceMock.MAX_ENROLLEE_ID + 1;
+                int notFoundEnrolleeId = enrollees.Max(e => e.Id.Value) + 1;
 
                 // create a request with an AUTH token
                 var request = TestUtils.CreateRequest(HttpMethod.Delete, $"/api/enrollees/{notFoundEnrolleeId}", Guid.NewGuid());
@@ -421,7 +421,7 @@ namespace PrimeTests.Controllers
                 Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
 
                 // check that the enrollee was not removed
-                Assert.True(service.EnrolleeExists(expectedEnrolleeId));
+                Assert.True(await service.EnrolleeExistsAsync(expectedEnrolleeId));
                 enrollees = await service.GetEnrolleesAsync(EMPTY_ENROLLEE_SEARCH_OPTIONS);
                 Assert.Equal(EnrolleeServiceMock.DEFAULT_ENROLLEES_SIZE, enrollees.Count());
             }
@@ -603,7 +603,7 @@ namespace PrimeTests.Controllers
                 Enrollee enrollee = enrollees.First();
 
                 // change the enrolleeId to one that will not be found
-                int notFoundEnrolleeId = EnrolleeServiceMock.MAX_ENROLLEE_ID + 1;
+                int notFoundEnrolleeId = enrollees.Max(e => e.Id.Value) + 1;
                 enrollee.Id = notFoundEnrolleeId;
 
                 // create a request with an AUTH token
@@ -745,7 +745,7 @@ namespace PrimeTests.Controllers
                 Assert.Equal(EnrolleeServiceMock.DEFAULT_ENROLLEES_SIZE, enrollees.Count());
 
                 // get an enrollee id that does not exist
-                int notFoundEnrolleeId = EnrolleeServiceMock.MAX_ENROLLEE_ID + 1;
+                int notFoundEnrolleeId = enrollees.Max(e => e.Id.Value) + 1;
 
                 // create a request with an AUTH token
                 var request = TestUtils.CreateRequest(HttpMethod.Get,
@@ -843,7 +843,7 @@ namespace PrimeTests.Controllers
                 Assert.Equal(EnrolleeServiceMock.DEFAULT_ENROLLEES_SIZE, enrollees.Count());
 
                 // get an enrollee id that does not exist
-                int notFoundEnrolleeId = EnrolleeServiceMock.MAX_ENROLLEE_ID + 1;
+                int notFoundEnrolleeId = enrollees.Max(e => e.Id.Value) + 1;
 
                 // create a request with an AUTH token
                 var request = TestUtils.CreateRequest(HttpMethod.Get,
@@ -940,7 +940,7 @@ namespace PrimeTests.Controllers
                 Assert.Equal(EnrolleeServiceMock.DEFAULT_ENROLLEES_SIZE, enrollees.Count());
 
                 // try to get an enrollee that does not exist
-                int notFoundEnrolleeId = EnrolleeServiceMock.MAX_ENROLLEE_ID + 1;
+                int notFoundEnrolleeId = enrollees.Max(e => e.Id.Value) + 1;
 
                 // create a request with an AUTH token
                 var request = TestUtils.CreateRequest<Status>(HttpMethod.Post,

--- a/prime-dotnet-webapi-tests/Mocks/BaseMockService.cs
+++ b/prime-dotnet-webapi-tests/Mocks/BaseMockService.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using System.Linq;
+
 using Prime.Models;
 
 namespace PrimeTests.Mocks
@@ -7,11 +9,6 @@ namespace PrimeTests.Mocks
     {
         public const int DEFAULT_ENROLMENTS_SIZE = 5;
         public const int DEFAULT_ENROLLEES_SIZE = 5;
-        public const int MIN_ENROLMENT_ID = 1;
-        public const int MAX_ENROLMENT_ID = 1000000;
-        public const int MIN_ENROLLEE_ID = 1;
-        public const int MAX_ENROLLEE_ID = 1000000;
-
         protected static short NULL_STATUS_CODE = -1;
 
         private static Dictionary<short, Status> _statusMap = new Dictionary<short, Status> {
@@ -145,6 +142,11 @@ namespace PrimeTests.Mocks
         {
             string key = typeof(T).FullName;
             return _fakeDb[key] as Dictionary<TKey, T>;
+        }
+
+        protected static int GetNewId(ICollection<int> ids)
+        {
+            return ids.DefaultIfEmpty(0).Max() + 1;
         }
     }
 }

--- a/prime-dotnet-webapi-tests/Mocks/EnrolleeServiceMock.cs
+++ b/prime-dotnet-webapi-tests/Mocks/EnrolleeServiceMock.cs
@@ -32,11 +32,10 @@ namespace PrimeTests.Mocks
 
         public Task<int?> CreateEnrolleeAsync(Enrollee enrollee)
         {
-            //add the ids, as this is just a fake implementation
-            int? enrolleeId = new Faker().Random.Int(MIN_ENROLMENT_ID, MAX_ENROLMENT_ID);
+            int? enrolleeId = GetNewId(this.GetHolder<int, Enrollee>().Keys);
             enrollee.Id = enrolleeId;
 
-            this.GetHolder<int, Enrollee>().Add((int)enrolleeId, enrollee);
+            this.GetHolder<int, Enrollee>().Add(enrolleeId.Value, enrollee);
             return Task.FromResult(enrolleeId);
         }
 
@@ -46,38 +45,43 @@ namespace PrimeTests.Mocks
             return Task.CompletedTask;
         }
 
-        public bool EnrolleeExists(int enrolleeId)
+        public Task<bool> EnrolleeExistsAsync(int enrolleeId)
         {
-            return this.GetHolder<int, Enrollee>().ContainsKey(enrolleeId);
+            return Task.FromResult(this.GetHolder<int, Enrollee>().ContainsKey(enrolleeId));
+        }
+
+        public Task<bool> EnrolleeUserIdExistsAsync(Guid userId)
+        {
+            var enrollees = this.GetHolder<int, Enrollee>().Values;
+            return Task.FromResult(enrollees.Any(e => e.UserId == userId));
         }
 
         public Task<Enrollee> GetEnrolleeAsync(int enrolleeId)
         {
             Enrollee enrollee = null;
-            if (this.GetHolder<int, Enrollee>().ContainsKey(enrolleeId))
-            {
-                enrollee = this.GetHolder<int, Enrollee>()[enrolleeId];
-            }
+            this.GetHolder<int, Enrollee>().TryGetValue(enrolleeId, out enrollee);
             return Task.FromResult(enrollee);
         }
 
         public Task<IEnumerable<Enrollee>> GetEnrolleesAsync(EnrolleeSearchOptions searchOptions)
         {
-            return Task.FromResult((IEnumerable<Enrollee>)this.GetHolder<int, Enrollee>().Values?.ToList());
+            IEnumerable<Enrollee> enrollees = this.GetHolder<int, Enrollee>().Values;
+            return Task.FromResult(enrollees);
         }
 
         public Task<int> UpdateEnrolleeAsync(Enrollee enrollee, bool profileCompleted)
         {
             int updated = 0;
-            int? enrolleeId = enrollee.Id;
-            if (enrolleeId != null)
+            if (enrollee.Id.HasValue)
             {
-                var found = this.GetHolder<int, Enrollee>().Remove((int)enrolleeId);
+                int id = enrollee.Id.Value;
+
+                var found = this.GetHolder<int, Enrollee>().Remove(id);
                 if (found)
                 {
                     updated = 1;
+                    this.GetHolder<int, Enrollee>().Add(id, enrollee);
                 }
-                this.GetHolder<int, Enrollee>().Add((int)enrolleeId, enrollee);
             }
             return Task.FromResult(updated);
         }
@@ -110,12 +114,10 @@ namespace PrimeTests.Mocks
 
         public Task<EnrolmentStatus> CreateEnrolmentStatusAsync(int enrolleeId, Status status)
         {
-            ICollection<Status> availableStatuses = new List<Status>();
-            Enrollee enrollee = null;
             EnrolmentStatus createdEnrolmentStatus = null;
             if (this.GetHolder<int, Enrollee>().ContainsKey(enrolleeId))
             {
-                enrollee = this.GetHolder<int, Enrollee>()[enrolleeId];
+                Enrollee enrollee = this.GetHolder<int, Enrollee>()[enrolleeId];
                 var currentStatusCode = enrollee.CurrentStatus?.StatusCode;
 
                 if (this.IsStatusChangeAllowed(this.GetHolder<short, Status>()[currentStatusCode ?? NULL_STATUS_CODE], status))
@@ -155,17 +157,44 @@ namespace PrimeTests.Mocks
             return Task.FromResult(false);
         }
 
-        public async Task<ICollection<AdjudicatorNote>> GetEnrolleeAdjudicatorNotesAsync(Enrollee enrollee)
+        public Task<IEnumerable<AdjudicatorNote>> GetEnrolleeAdjudicatorNotesAsync(Enrollee enrollee)
         {
-            // TODO add proper tests, but need test spike
-            return new List<AdjudicatorNote>() { new AdjudicatorNote() };
+            // TODO add proper tests, but need test spike. Add adjudicatorNote to fake db.
+            IEnumerable<AdjudicatorNote> notes = new[] { new AdjudicatorNote() };
+            return Task.FromResult(notes);
         }
 
-        public async Task<AdjudicatorNote> CreateAdjudicatorNoteAsync(Enrollee enrollee, AdjudicatorNote adjudicatorNote)
+        public Task<AdjudicatorNote> CreateEnrolleeAdjudicatorNoteAsync(int enrolleeId, AdjudicatorNote adjudicatorNote)
+        {
+            // TODO add proper tests, but need test spike. Add adjudicatorNote to fake db.
+            return Task.FromResult(adjudicatorNote);
+        }
+
+        public Task<IEnrolleeNote> UpdateEnrolleeNoteAsync(int enrolleeId, IEnrolleeNote newNote)
         {
             // TODO add proper tests, but need test spike
-            AdjudicatorNote newAdjudicatorNote = new AdjudicatorNote { Enrollee = enrollee, Note = adjudicatorNote.Note };
-            return newAdjudicatorNote;
+            IEnrolleeNote updatedNote = null;
+            if (this.GetHolder<int, Enrollee>().ContainsKey(enrolleeId))
+            {
+                var enrollee = this.GetHolder<int, Enrollee>()[enrolleeId];
+
+                if (newNote.GetType() == typeof(AccessAgreementNote))
+                {
+                    enrollee.AccessAgreementNote = (AccessAgreementNote)newNote;
+                }
+                else if (newNote.GetType() == typeof(EnrolmentCertificateNote))
+                {
+                    enrollee.EnrolmentCertificateNote = (EnrolmentCertificateNote)newNote;
+                }
+                else
+                {
+                    throw new ArgumentException("Enrollee note type is not recognized, or not allowed.");
+                }
+
+                updatedNote = newNote;
+            }
+
+            return Task.FromResult(updatedNote);
         }
     }
 }

--- a/prime-dotnet-webapi-tests/Utils/TestUtils.cs
+++ b/prime-dotnet-webapi-tests/Utils/TestUtils.cs
@@ -113,10 +113,10 @@ namespace PrimeTests.Utils
 
         public static void RemoveAdminRoleFromUser(ClaimsPrincipal user)
         {
+            var claim = user.Claims
+                .Where(c => c.Value == PrimeConstants.PRIME_ADMIN_ROLE)
+                .Single();
             var identity = user.Identity as ClaimsIdentity;
-            var claim = (from c in user.Claims
-                         where c.Value == PrimeConstants.PRIME_ADMIN_ROLE
-                         select c).Single();
             identity.RemoveClaim(claim);
         }
 

--- a/prime-dotnet-webapi/Controllers/EnrolleesController.cs
+++ b/prime-dotnet-webapi/Controllers/EnrolleesController.cs
@@ -25,25 +25,6 @@ namespace Prime.Controllers
             _enrolleeService = enrolleeService;
         }
 
-        private bool BelongsToEnrollee(Enrollee enrollee)
-        {
-            bool belongsToEnrollee = false;
-
-            // Check to see if the logged in user is an admin
-            belongsToEnrollee = User.IsInRole(PrimeConstants.PRIME_ADMIN_ROLE);
-
-            // If user is not ADMIN, check that user belongs to the enrolment
-            if (!belongsToEnrollee)
-            {
-                // Get the prime user id from the logged in user - note: this returns 'Guid.Empty' if there is no logged in user
-                Guid PrimeUserId = User.GetPrimeUserId();
-                // Check to see if the logged in user id is not 'Guid.Empty', and matches the one in the enrolment
-                belongsToEnrollee = !PrimeUserId.Equals(Guid.Empty) && PrimeUserId.Equals(enrollee.UserId);
-            }
-
-            return belongsToEnrollee;
-        }
-
         // GET: api/Enrollees
         /// <summary>
         /// Gets all of the enrollees for the user, or all enrollees if user has ADMIN role.
@@ -96,8 +77,7 @@ namespace Prime.Controllers
                 return NotFound(new ApiResponse(404, $"Enrollee not found with id {enrolleeId}"));
             }
 
-            // if the user is not an ADMIN, make sure the enrolleeId matches the user, otherwise return not authorized
-            if (!BelongsToEnrollee(enrollee))
+            if (!User.CanAccess(enrollee))
             {
                 return Forbid();
             }
@@ -161,7 +141,7 @@ namespace Prime.Controllers
                 return BadRequest(new ApiBadRequestResponse(this.ModelState));
             }
 
-            if (enrollee == null || enrollee.Id == null)
+            if (enrollee.Id == null)
             {
                 this.ModelState.AddModelError("Enrollee.Id", "Enrollee Id is required to make updates.");
                 return BadRequest(new ApiBadRequestResponse(this.ModelState));
@@ -187,8 +167,7 @@ namespace Prime.Controllers
                 return BadRequest(new ApiBadRequestResponse(this.ModelState));
             }
 
-            // If the user is not an ADMIN, make sure the enrolleeId matches the user, otherwise return not authorized
-            if (!BelongsToEnrollee(enrollee))
+            if (!User.CanAccess(enrollee))
             {
                 return Forbid();
             }
@@ -216,8 +195,7 @@ namespace Prime.Controllers
                 return NotFound(new ApiResponse(404, $"Enrollee not found with id {enrolleeId}"));
             }
 
-            // if the user is not an ADMIN, make sure the enrolleeId matches the user, otherwise return not authorized
-            if (!BelongsToEnrollee(enrollee))
+            if (!User.CanAccess(enrollee))
             {
                 return Forbid();
             }
@@ -247,8 +225,7 @@ namespace Prime.Controllers
                 return NotFound(new ApiResponse(404, $"Enrollee not found with id {enrolleeId}"));
             }
 
-            // if the user is not an ADMIN, make sure the enrolleeId matches the user, otherwise return not authorized
-            if (!BelongsToEnrollee(enrollee))
+            if (!User.CanAccess(enrollee))
             {
                 return Forbid();
             }
@@ -278,8 +255,7 @@ namespace Prime.Controllers
                 return NotFound(new ApiResponse(404, $"Enrollee not found with id {enrolleeId}"));
             }
 
-            // if the user is not an ADMIN, make sure the enrolleeId matches the user, otherwise return not authorized
-            if (!BelongsToEnrollee(enrollee))
+            if (!User.CanAccess(enrollee))
             {
                 return Forbid();
             }
@@ -314,8 +290,7 @@ namespace Prime.Controllers
                 return BadRequest(new ApiBadRequestResponse(this.ModelState));
             }
 
-            // if the user is not an ADMIN, make sure the enrolleeId matches the user, otherwise return not authorized
-            if (!BelongsToEnrollee(enrollee))
+            if (!User.CanAccess(enrollee))
             {
                 return Forbid();
             }
@@ -352,8 +327,7 @@ namespace Prime.Controllers
                 return NotFound(new ApiResponse(404, $"Enrollee not found with id {enrolleeId}"));
             }
 
-            // If the user is not an ADMIN, make sure the enrollee ID matches the user, otherwise return not authorized
-            if (!BelongsToEnrollee(enrollee))
+            if (!User.CanAccess(enrollee))
             {
                 return Forbid();
             }
@@ -382,12 +356,6 @@ namespace Prime.Controllers
             if (!await _enrolleeService.EnrolleeExists(enrolleeId))
             {
                 return NotFound(new ApiResponse(404, $"Enrollee not found with id {enrolleeId}"));
-            }
-
-            // If the user is not an ADMIN, make sure the enrollee ID matches the user, otherwise return not authorized
-            if (!BelongsToEnrollee(enrollee))
-            {
-                return Forbid();
             }
 
             if (enrolleeId != adjudicatorNote.EnrolleeId)

--- a/prime-dotnet-webapi/Extensions/ClaimsPrincipalExensions.cs
+++ b/prime-dotnet-webapi/Extensions/ClaimsPrincipalExensions.cs
@@ -2,6 +2,8 @@ using System;
 using System.Linq;
 using System.Security.Claims;
 
+using Prime.Models;
+
 namespace Prime
 {
     public static class ClaimsPrincipalExensions
@@ -13,6 +15,20 @@ namespace Prime
         {
             string userId = User?.Identity?.Name;
             return userId != null ? new Guid(userId) : Guid.Empty;
+        }
+
+        /// <summary>
+        /// Returns true if the logged in user is an admin, or if the user has the same UserId as the record
+        /// </summary>
+        public static bool CanAccess(this ClaimsPrincipal User, Enrollee enrollee)
+        {
+            if (User.IsInRole(PrimeConstants.PRIME_ADMIN_ROLE))
+            {
+                return true;
+            }
+
+            Guid PrimeUserId = User.GetPrimeUserId();
+            return !PrimeUserId.Equals(Guid.Empty) && PrimeUserId.Equals(enrollee.UserId);
         }
 
         public static bool HasAssuranceLevel(this ClaimsPrincipal User, int level)

--- a/prime-dotnet-webapi/Services/DefaultEnrolleeService.cs
+++ b/prime-dotnet-webapi/Services/DefaultEnrolleeService.cs
@@ -99,9 +99,16 @@ namespace Prime.Services
             return availableStatuses;
         }
 
-        public bool EnrolleeExists(Guid userId)
+        public async Task<bool> EnrolleeExistsAsync(int enrolleeId)
         {
-            return _context.Enrollees.Any(e => e.UserId == userId);
+            return await _context.Enrollees
+                .AnyAsync(e => e.Id == enrolleeId);
+        }
+
+        public async Task<bool> EnrolleeUserIdExistsAsync(Guid userId)
+        {
+            return await _context.Enrollees
+                .AnyAsync(e => e.UserId == userId);
         }
 
         public async Task<Enrollee> GetEnrolleeAsync(Guid userId)
@@ -385,16 +392,16 @@ namespace Prime.Services
                         };
                         break;
                     case Status.DECLINED_CODE:
-                        await setAllPharmaNetStatusesFalseAsync(enrolleeId);
+                        await SetAllPharmaNetStatusesFalseAsync(enrolleeId);
                         createdEnrolmentStatus.PharmaNetStatus = true;
                         break;
                     case Status.ACCEPTED_TOS_CODE:
-                        await setAllPharmaNetStatusesFalseAsync(enrolleeId);
+                        await SetAllPharmaNetStatusesFalseAsync(enrolleeId);
                         enrollee.LicensePlate = this.GenerateLicensePlate();
                         createdEnrolmentStatus.PharmaNetStatus = true;
                         break;
                     case Status.DECLINED_TOS_CODE:
-                        await setAllPharmaNetStatusesFalseAsync(enrolleeId);
+                        await SetAllPharmaNetStatusesFalseAsync(enrolleeId);
                         createdEnrolmentStatus.PharmaNetStatus = true;
                         break;
                 }
@@ -423,7 +430,7 @@ namespace Prime.Services
             throw new InvalidOperationException("Could not create enrolment status, status change is not allowed.");
         }
 
-        private async Task setAllPharmaNetStatusesFalseAsync(int enrolleeId)
+        private async Task SetAllPharmaNetStatusesFalseAsync(int enrolleeId)
         {
             var existingEnrolmentStatuses = await this.GetEnrolmentStatusesAsync(enrolleeId);
 
@@ -472,12 +479,6 @@ namespace Prime.Services
                     .Include(e => e.EnrolmentStatuses).ThenInclude(es => es.EnrolmentStatusReasons).ThenInclude(esr => esr.StatusReason)
                     .Include(e => e.AccessAgreementNote)
                     .Include(e => e.EnrolmentCertificateNote);
-        }
-
-        public async Task<bool> EnrolleeExists(int enrolleeId)
-        {
-            return await _context.Enrollees
-                .AnyAsync(e => e.Id == enrolleeId);
         }
 
         public async Task<Enrollee> GetEnrolleeAsync(int enrolleeId)

--- a/prime-dotnet-webapi/Services/IEnrolleeService.cs
+++ b/prime-dotnet-webapi/Services/IEnrolleeService.cs
@@ -38,6 +38,6 @@ namespace Prime.Services
 
         Task<AdjudicatorNote> CreateEnrolleeAdjudicatorNoteAsync(int enrolleeId, AdjudicatorNote adjudicatorNote);
 
-        Task<IEnrolleeNote> UpdateEnrolleeNoteAsync(int enrolleeId, IEnrolleeNote UpdateEnrolleeNoteAsync);
+        Task<IEnrolleeNote> UpdateEnrolleeNoteAsync(int enrolleeId, IEnrolleeNote newNote);
     }
 }

--- a/prime-dotnet-webapi/Services/IEnrolleeService.cs
+++ b/prime-dotnet-webapi/Services/IEnrolleeService.cs
@@ -10,7 +10,9 @@ namespace Prime.Services
     {
         Task<Enrollee> GetEnrolleeForUserIdAsync(Guid userId);
 
-        Task<bool> EnrolleeExists(int enrolleeId);
+        Task<bool> EnrolleeExistsAsync(int enrolleeId);
+
+        Task<bool> EnrolleeUserIdExistsAsync(Guid userId);
 
         Task<Enrollee> GetEnrolleeAsync(int enrolleeId);
 


### PR DESCRIPTION
Refactorings:
- Removed random generation of enrollee Ids from enrollee service mock. Replaced with new utility method on base service mock class. Removed unnecessary constants.
- Removed a lot of unnecessary casts and unused variables from tests. Minor syntactic changes for readability.
- BelongsToEnrollee is now an extension method on ClaimsPrincipal rather than in the enrollee controller. Renamed to CanAccess.
- Added EnrolleeUserIdExistsAsync method to the enrollee service. Interface and mock have been updated. Renamed EnrolleeExists to EnrolleeExistsAsync.
- Moved CanAccess up in the execution sequence for some controller methods, generally right after checking if the enrollee object is null. Check auth as soon as possible. 
- Capitallized setAllPharmaNetStatusesFalseAsync.
- Refactored GetAvailableStatuses


Functional changes:
- Added CanAccess to CreateEnrollee. Before, enrollees could create enrollee objects with arbitrary user ids.  
- In the notes section, removed some console.writeLines and Uncommented some code that looked like they were missed. Slightly changed wording of error messages.
- Made EnrolleeExists async.
