### PR TITLE
Validation on Summary

### DIFF
--- a/prime-angular-frontend/src/app/modules/adjudication/pages/enrolment/enrolment.component.spec.ts
+++ b/prime-angular-frontend/src/app/modules/adjudication/pages/enrolment/enrolment.component.spec.ts
@@ -23,6 +23,7 @@ import { EnrolleePipe } from '@shared/pipes/enrollee.pipe';
 import { YesNoPipe } from '@shared/pipes/yes-no.pipe';
 import { EnrolleePropertyComponent } from '@shared/components/enrollee/enrollee-property/enrollee-property.component';
 import { PageComponent } from '@shared/components/page/page.component';
+import { EnrolleePropertyErrorComponent } from '@shared/components/enrollee/enrollee-property-error/enrollee-property-error.component';
 
 describe('EnrolmentComponent', () => {
   let component: EnrolmentComponent;
@@ -55,7 +56,8 @@ describe('EnrolmentComponent', () => {
           PostalPipe,
           DefaultPipe,
           EnrolleePipe,
-          YesNoPipe
+          YesNoPipe,
+          EnrolleePropertyErrorComponent
         ],
         providers: [
           {

--- a/prime-angular-frontend/src/app/modules/enrolment/pages/job/job.component.ts
+++ b/prime-angular-frontend/src/app/modules/enrolment/pages/job/job.component.ts
@@ -44,7 +44,7 @@ export class JobComponent extends BaseEnrolmentProfilePage implements OnInit, On
 
     this.jobNames = this.configService.jobNames;
     this.filteredJobNames = new BehaviorSubject<Config<number>[]>(this.jobNames);
-    this.allowDefaultOption = true;
+    this.allowDefaultOption = false;
     this.defaultOptionLabel = 'None';
   }
 

--- a/prime-angular-frontend/src/app/modules/enrolment/pages/overview/overview.component.html
+++ b/prime-angular-frontend/src/app/modules/enrolment/pages/overview/overview.component.html
@@ -24,7 +24,7 @@
     <mat-icon matTooltip="Action Required"
               matTooltipPosition="after"
               class="red">warning</mat-icon>
-    Action Required: If no College Certification is entered, Job Title is a required field.
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
   </div>
 
   <app-page-subheader>

--- a/prime-angular-frontend/src/app/modules/enrolment/pages/overview/overview.component.html
+++ b/prime-angular-frontend/src/app/modules/enrolment/pages/overview/overview.component.html
@@ -19,6 +19,14 @@
     </app-page-subheader>
   </div>
 
+  <div *ngIf="!isAnyJobOrReg()"
+       class="mb-4 red">
+    <mat-icon matTooltip="Action Required"
+              matTooltipPosition="after"
+              class="red">warning</mat-icon>
+    Action Required: If no College Certification is entered, Job Title is a required field.
+  </div>
+
   <app-page-subheader>
     <ng-container appPageSubheaderTitle>Personal Information from BC Services Card</ng-container>
   </app-page-subheader>
@@ -38,7 +46,7 @@
 
       <button mat-flat-button
               color="primary"
-              [disabled]="!accept.checked"
+              [disabled]="!accept.checked || !isAnyJobOrReg()"
               (click)="onSubmit()">Submit Enrolment</button>
 
     </div>

--- a/prime-angular-frontend/src/app/modules/enrolment/pages/overview/overview.component.scss
+++ b/prime-angular-frontend/src/app/modules/enrolment/pages/overview/overview.component.scss
@@ -6,6 +6,10 @@
   font-size: 1.35rem;
 }
 
+.red {
+  color: theme-palette(red);
+}
+
 .footer {
   border-top: 2px solid theme-palette(grey, lighter);
   padding-top: 1rem;

--- a/prime-angular-frontend/src/app/modules/enrolment/pages/overview/overview.component.spec.ts
+++ b/prime-angular-frontend/src/app/modules/enrolment/pages/overview/overview.component.spec.ts
@@ -38,6 +38,7 @@ import { EnrolleePropertyComponent } from '@shared/components/enrollee/enrollee-
 import { PrimeContactComponent } from '@shared/components/prime-contact/prime-contact.component';
 import { PrimeEmailComponent } from '@shared/components/prime-email/prime-email.component';
 import { PrimePhoneComponent } from '@shared/components/prime-phone/prime-phone.component';
+import { EnrolleePropertyErrorComponent } from '@shared/components/enrollee/enrollee-property-error/enrollee-property-error.component';
 
 describe('OverviewComponent', () => {
   let component: OverviewComponent;
@@ -77,7 +78,8 @@ describe('OverviewComponent', () => {
           PostalPipe,
           DefaultPipe,
           EnrolleePipe,
-          YesNoPipe
+          YesNoPipe,
+          EnrolleePropertyErrorComponent
         ],
         providers: [
           {

--- a/prime-angular-frontend/src/app/modules/enrolment/pages/overview/overview.component.ts
+++ b/prime-angular-frontend/src/app/modules/enrolment/pages/overview/overview.component.ts
@@ -40,6 +40,10 @@ export class OverviewComponent extends BaseEnrolmentPage implements OnInit {
     super(route, router);
   }
 
+  public isAnyJobOrReg(): boolean {
+    return this.enrolmentStateService.isAnyJobOrReg();
+  }
+
   public onSubmit() {
     if (this.enrolmentStateService.isEnrolmentValid()) {
       const enrolment = this.enrolmentStateService.enrolment;
@@ -72,12 +76,12 @@ export class OverviewComponent extends BaseEnrolmentPage implements OnInit {
       console.log('JOBS', this.enrolmentStateService.isJobsValid());
       console.log('DECLARATION', this.enrolmentStateService.isSelfDeclarationValid());
       console.log('ACCESS', this.enrolmentStateService.isOrganizationValid());
+      console.log('ANY ( JOB || REGULATORY )', this.enrolmentStateService.isAnyJobOrReg());
     }
   }
 
   public ngOnInit() {
     const enrolment = this.enrolmentService.enrolment;
-
     this.enrolment = enrolment;
     this.enrolmentStateService.enrolment = enrolment;
     this.isInitialEnrolment = enrolment.progressStatus !== ProgressStatus.FINISHED;

--- a/prime-angular-frontend/src/app/modules/enrolment/shared/services/enrolment-state.service.ts
+++ b/prime-angular-frontend/src/app/modules/enrolment/shared/services/enrolment-state.service.ts
@@ -82,8 +82,19 @@ export class EnrolmentStateService {
       this.isDeviceProviderValid() &&
       this.isJobsValid() &&
       this.isSelfDeclarationValid() &&
-      this.isOrganizationValid()
+      this.isOrganizationValid() &&
+      this.isAnyJobOrReg()
     );
+  }
+
+  /**
+   * Returns true if a Job or Regulatory has been entered.
+   */
+  public isAnyJobOrReg(): boolean {
+    const jobs = this.jobsForm.get('jobs') as FormArray;
+    const certifications = this.regulatoryForm.get('certifications') as FormArray;
+    // When you set cert to 'None' there still exists an item in FormArray, this checks for that state
+    return jobs.length > 0 || (certifications.length > 0 && (certifications.value[0].licenseNumber !== null));
   }
 
   public isProfileInfoValid(): boolean {

--- a/prime-angular-frontend/src/app/shared/components/enrollee/enrollee-property-error/enrollee-property-error.component.html
+++ b/prime-angular-frontend/src/app/shared/components/enrollee/enrollee-property-error/enrollee-property-error.component.html
@@ -1,4 +1,4 @@
-<div class="mb-2 container-fluid">
+<div class="mb-2 d-flex">
   <span>
     <ng-content></ng-content>
   </span>

--- a/prime-angular-frontend/src/app/shared/components/enrollee/enrollee-property-error/enrollee-property-error.component.html
+++ b/prime-angular-frontend/src/app/shared/components/enrollee/enrollee-property-error/enrollee-property-error.component.html
@@ -1,0 +1,15 @@
+<div class="mb-2 container-fluid">
+  <span>
+    <ng-content></ng-content>
+  </span>
+  <span class="flex-grow-1"></span>
+  <span>
+    <button mat-icon-button
+    type="button"
+    (click)="onEvent()">
+      <mat-icon [matTooltip]="message"
+        matTooltipPosition="after"
+        class="icon">warning</mat-icon>
+    </button>
+  </span>
+</div>

--- a/prime-angular-frontend/src/app/shared/components/enrollee/enrollee-property-error/enrollee-property-error.component.scss
+++ b/prime-angular-frontend/src/app/shared/components/enrollee/enrollee-property-error/enrollee-property-error.component.scss
@@ -1,0 +1,9 @@
+@import 'palette';
+
+.container-fluid {
+  display: flex;
+}
+
+.icon {
+  color: theme-palette(red);
+}

--- a/prime-angular-frontend/src/app/shared/components/enrollee/enrollee-property-error/enrollee-property-error.component.scss
+++ b/prime-angular-frontend/src/app/shared/components/enrollee/enrollee-property-error/enrollee-property-error.component.scss
@@ -1,9 +1,5 @@
 @import 'palette';
 
-.container-fluid {
-  display: flex;
-}
-
 .icon {
   color: theme-palette(red);
 }

--- a/prime-angular-frontend/src/app/shared/components/enrollee/enrollee-property-error/enrollee-property-error.component.spec.ts
+++ b/prime-angular-frontend/src/app/shared/components/enrollee/enrollee-property-error/enrollee-property-error.component.spec.ts
@@ -1,0 +1,31 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { EnrolleePropertyErrorComponent } from './enrollee-property-error.component';
+import { NgxContextualHelpModule } from '@shared/modules/ngx-contextual-help/ngx-contextual-help.module';
+import { NgxMaterialModule } from '@shared/modules/ngx-material/ngx-material.module';
+
+describe('EnrolleePropertyErrorComponent', () => {
+  let component: EnrolleePropertyErrorComponent;
+  let fixture: ComponentFixture<EnrolleePropertyErrorComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NgxContextualHelpModule,
+        NgxMaterialModule
+      ],
+      declarations: [EnrolleePropertyErrorComponent]
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(EnrolleePropertyErrorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/prime-angular-frontend/src/app/shared/components/enrollee/enrollee-property-error/enrollee-property-error.component.ts
+++ b/prime-angular-frontend/src/app/shared/components/enrollee/enrollee-property-error/enrollee-property-error.component.ts
@@ -1,0 +1,18 @@
+import { Component, OnInit, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-enrollee-property-error',
+  templateUrl: './enrollee-property-error.component.html',
+  styleUrls: ['./enrollee-property-error.component.scss']
+})
+export class EnrolleePropertyErrorComponent implements OnInit {
+  @Input() public message: string;
+
+  constructor() {
+    this.message = 'Error';
+  }
+
+  ngOnInit() {
+  }
+
+}

--- a/prime-angular-frontend/src/app/shared/components/enrollee/enrollee-review/enrollee-review.component.html
+++ b/prime-angular-frontend/src/app/shared/components/enrollee/enrollee-review/enrollee-review.component.html
@@ -172,19 +172,19 @@
   </app-page-subheader>
 
   <ng-container *ngFor="let job of jobs">
-
     <app-enrollee-property title="Job Title"
                            [makeBold]="true">
       {{ job.title | default }}
     </app-enrollee-property>
-
   </ng-container>
 
-  <app-enrollee-property *ngIf="!hasJob"
-                         title="Job Title"
-                         [makeBold]="true">
-    None
-  </app-enrollee-property>
+  <app-enrollee-property-error message="If no College Certification is entered a Job Title is required."
+                               *ngIf="!hasJob">
+    <app-enrollee-property title="Job Title"
+                           [makeBold]="true">
+      None
+    </app-enrollee-property>
+  </app-enrollee-property-error>
 
 </section>
 

--- a/prime-angular-frontend/src/app/shared/shared.module.ts
+++ b/prime-angular-frontend/src/app/shared/shared.module.ts
@@ -48,6 +48,7 @@ import { EnrolleeOrganizationsComponent } from '@shared/components/enrollee/enro
 import { PrimeContactComponent } from '@shared/components/prime-contact/prime-contact.component';
 import { PrimeEmailComponent } from './components/prime-email/prime-email.component';
 import { PrimePhoneComponent } from './components/prime-phone/prime-phone.component';
+import { EnrolleePropertyErrorComponent } from './components/enrollee/enrollee-property-error/enrollee-property-error.component';
 
 @NgModule({
   declarations: [
@@ -86,7 +87,8 @@ import { PrimePhoneComponent } from './components/prime-phone/prime-phone.compon
     EnrolleePropertyComponent,
     PrimeContactComponent,
     PrimeEmailComponent,
-    PrimePhoneComponent
+    PrimePhoneComponent,
+    EnrolleePropertyErrorComponent
   ],
   imports: [
     CommonModule,


### PR DESCRIPTION
added prelim validation on summary such that a user is required to either have a college cert or a job title.

This works through the enrollee state service. As it now have a check for if a cert or job exists.

This then will display a red warning at the top of the summary page as well as an icon next to the job title field. It will also disable the submit button. 

Also for the job form page disabled allow the default "None" so you are required to select a job title once you get to this screen either through the wizard or by spoking to it