### PR TITLE
Update local dev PharmaNet college api mock

### DIFF
--- a/prime-dotnet-webapi/Services/PharmanetAPIService.cs
+++ b/prime-dotnet-webapi/Services/PharmanetAPIService.cs
@@ -98,14 +98,13 @@ namespace Prime.Services
 
         private PharmanetCollegeRecord LocalDevApiMock(string licenceNumber)
         {
-            if (licenceNumber == "99999")
+            if (licenceNumber == "error")
             {
                 throw new PharmanetCollegeApiException();
             }
 
-            // last two digits
-            var userNumber = Int32.Parse(licenceNumber.Substring(3));
-            if (userNumber < 1 || userNumber > 11)
+            int parsed;
+            if (!Int32.TryParse(licenceNumber, out parsed) ||  parsed < 1 || parsed > 11)
             {
                 return null;
             }
@@ -125,7 +124,7 @@ namespace Prime.Services
                 new {Date = "2000-05-30", Name = "TEN"},
                 new {Date = "2000-06-07", Name = "ELEVEN"}
             };
-            var info = lookup[userNumber];
+            var info = lookup[parsed];
 
             return new PharmanetCollegeRecord
             {


### PR DESCRIPTION
Pharmanet mock API for local dev is updated based on licence numbers now being alphanumeric and any length.

Parses entire licence number rather than taking the last two digits. Returns the record matching that test card number, but only in the range of 1 to 11. Any other number or parse error is null. Enter "error" for licence number and the mock will throw an error.