### PR TITLE
changing to 30 second checks, fail on 10 second returns.

### DIFF
--- a/openshift/dotnet-webapi.dc.yaml
+++ b/openshift/dotnet-webapi.dc.yaml
@@ -189,9 +189,9 @@ objects:
                   port: 8080
                   scheme: "HTTP"
                 initialDelaySeconds: 30
-                periodSeconds: 10
+                periodSeconds: 30
                 successThreshold: 1
-                timeoutSeconds: 1
+                timeoutSeconds: 10
               resources: {}
               volumeMounts:
                 - name: cert-volume


### PR DESCRIPTION
.NET is taking a while to respond 200 on healthcheck endpoint.  This adds more tolerance.