### PR TITLE
Common Dependancy Injection

### DIFF
--- a/prime-dotnet-webapi/Services/AccessTermService.cs
+++ b/prime-dotnet-webapi/Services/AccessTermService.cs
@@ -11,8 +11,8 @@ namespace Prime.Services
     public class AccessTermService : BaseService, IAccessTermService
     {
         private static readonly TimeSpan ACCESS_TERM_EXPIRY = TimeSpan.FromDays(365);
-        public AccessTermService(
-            ApiDbContext context, IHttpContextAccessor httpContext) : base(context, httpContext)
+        public AccessTermService(IServiceProvider provider)
+            : base(provider)
         { }
 
         /**

--- a/prime-dotnet-webapi/Services/AdminService.cs
+++ b/prime-dotnet-webapi/Services/AdminService.cs
@@ -10,10 +10,8 @@ namespace Prime.Services
 {
     public class AdminService : BaseService, IAdminService
     {
-        public AdminService(
-            ApiDbContext context,
-            IHttpContextAccessor httpContext)
-            : base(context, httpContext)
+        public AdminService(IServiceProvider provider)
+            : base(provider)
         { }
 
         public async Task<bool> AdminExistsAsync(int adminId)

--- a/prime-dotnet-webapi/Services/AutomaticAdjudicationService.cs
+++ b/prime-dotnet-webapi/Services/AutomaticAdjudicationService.cs
@@ -14,9 +14,9 @@ namespace Prime.Services
     {
         private readonly List<IAutomaticAdjudicationRule> _rules;
 
-        public AutomaticAdjudicationService(
-            ApiDbContext context, IHttpContextAccessor httpContext, IPharmanetApiService pharmanetApiService)
-            : base(context, httpContext)
+        public AutomaticAdjudicationService(IServiceProvider provider,
+            IPharmanetApiService pharmanetApiService)
+            : base(provider)
         {
             _rules = new List<IAutomaticAdjudicationRule>
             {

--- a/prime-dotnet-webapi/Services/BaseService.cs
+++ b/prime-dotnet-webapi/Services/BaseService.cs
@@ -1,17 +1,18 @@
+using System;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Prime.Services
 {
     public abstract class BaseService
     {
         protected readonly ApiDbContext _context;
-
         protected readonly IHttpContextAccessor _httpContext;
 
-        protected BaseService(ApiDbContext context, IHttpContextAccessor httpContext)
+        protected BaseService(IServiceProvider provider)
         {
-            _context = context;
-            _httpContext = httpContext;
+            _context = provider.GetService<ApiDbContext>();
+            _httpContext = provider.GetService<IHttpContextAccessor>();
         }
     }
 }

--- a/prime-dotnet-webapi/Services/BaseService.cs
+++ b/prime-dotnet-webapi/Services/BaseService.cs
@@ -11,8 +11,8 @@ namespace Prime.Services
 
         protected BaseService(IServiceProvider provider)
         {
-            _context = provider.GetService<ApiDbContext>();
-            _httpContext = provider.GetService<IHttpContextAccessor>();
+            _context = provider.GetRequiredService<ApiDbContext>();
+            _httpContext = provider.GetRequiredService<IHttpContextAccessor>();
         }
     }
 }

--- a/prime-dotnet-webapi/Services/BusinessEventService.cs
+++ b/prime-dotnet-webapi/Services/BusinessEventService.cs
@@ -11,7 +11,13 @@ namespace Prime.Services
             ApiDbContext context, IHttpContextAccessor httpContext) : base(context, httpContext)
         { }
 
+<<<<<<< HEAD
         public async Task<BusinessEvent> CreateStatusChangeEventAsync(int enrolleeId, string description, int? adminId = null)
+=======
+        public BusinessEventService(IServiceProvider provider,
+            IAdminService adminService)
+            : base(provider)
+>>>>>>> 64d2346... di
         {
             var businessEvent = this.CreateBusinessEvent(BusinessEventType.STATUS_CHANGE_CODE, enrolleeId, description, adminId);
             _context.BusinessEvents.Add(businessEvent);

--- a/prime-dotnet-webapi/Services/BusinessEventService.cs
+++ b/prime-dotnet-webapi/Services/BusinessEventService.cs
@@ -7,17 +7,11 @@ namespace Prime.Services
 {
     public class BusinessEventService : BaseService, IBusinessEventService
     {
-        public BusinessEventService(
-            ApiDbContext context, IHttpContextAccessor httpContext) : base(context, httpContext)
+        public BusinessEventService(IServiceProvider provider)
+            : base(provider)
         { }
 
-<<<<<<< HEAD
         public async Task<BusinessEvent> CreateStatusChangeEventAsync(int enrolleeId, string description, int? adminId = null)
-=======
-        public BusinessEventService(IServiceProvider provider,
-            IAdminService adminService)
-            : base(provider)
->>>>>>> 64d2346... di
         {
             var businessEvent = this.CreateBusinessEvent(BusinessEventType.STATUS_CHANGE_CODE, enrolleeId, description, adminId);
             _context.BusinessEvents.Add(businessEvent);

--- a/prime-dotnet-webapi/Services/EmailService.cs
+++ b/prime-dotnet-webapi/Services/EmailService.cs
@@ -12,8 +12,8 @@ namespace Prime.Services
     {
         private const string PRIME_EMAIL = "no-reply-prime@gov.bc.ca";
 
-        public EmailService(ApiDbContext context, IHttpContextAccessor httpContext)
-            : base(context, httpContext)
+        public EmailService(IServiceProvider provider)
+            : base(provider)
         { }
 
         public static bool IsValidEmail(string email)

--- a/prime-dotnet-webapi/Services/EnrolleeProfileVersionService.cs
+++ b/prime-dotnet-webapi/Services/EnrolleeProfileVersionService.cs
@@ -20,10 +20,8 @@ namespace Prime.Services
             }
         );
 
-        public EnrolleeProfileVersionService(
-            ApiDbContext context,
-            IHttpContextAccessor httpContext
-            ) : base(context, httpContext)
+        public EnrolleeProfileVersionService(IServiceProvider provider)
+            : base(provider)
         { }
 
         public async Task<IEnumerable<EnrolleeProfileVersion>> GetEnrolleeProfileVersionsAsync(int enrolleeId)

--- a/prime-dotnet-webapi/Services/EnrolleeService.cs
+++ b/prime-dotnet-webapi/Services/EnrolleeService.cs
@@ -20,6 +20,7 @@ namespace Prime.Services
         private readonly IEnrolleeProfileVersionService _enroleeProfileVersionService;
         private readonly IBusinessEventService _businessEventService;
 
+<<<<<<<
         private class StatusWrapper
         {
             public Status Status { get; set; }
@@ -33,13 +34,16 @@ namespace Prime.Services
         public EnrolleeService(
             ApiDbContext context,
             IHttpContextAccessor httpContext,
+=======
+        public EnrolleeService(IServiceProvider provider,
+>>>>>>>
             IAutomaticAdjudicationService automaticAdjudicationService,
             IEmailService emailService,
             IPrivilegeService privilegeService,
             IAccessTermService accessTermService,
             IEnrolleeProfileVersionService enroleeProfileVersionService,
             IBusinessEventService businessEventService)
-            : base(context, httpContext)
+            : base(provider)
         {
             _automaticAdjudicationService = automaticAdjudicationService;
             _emailService = emailService;

--- a/prime-dotnet-webapi/Services/EnrolleeService.cs
+++ b/prime-dotnet-webapi/Services/EnrolleeService.cs
@@ -20,7 +20,6 @@ namespace Prime.Services
         private readonly IEnrolleeProfileVersionService _enroleeProfileVersionService;
         private readonly IBusinessEventService _businessEventService;
 
-<<<<<<<
         private class StatusWrapper
         {
             public Status Status { get; set; }
@@ -31,12 +30,7 @@ namespace Prime.Services
 
         private static Status NULL_STATUS = new Status { Code = -1, Name = "No Status" };
 
-        public EnrolleeService(
-            ApiDbContext context,
-            IHttpContextAccessor httpContext,
-=======
         public EnrolleeService(IServiceProvider provider,
->>>>>>>
             IAutomaticAdjudicationService automaticAdjudicationService,
             IEmailService emailService,
             IPrivilegeService privilegeService,

--- a/prime-dotnet-webapi/Services/EnrolmentCertificateService.cs
+++ b/prime-dotnet-webapi/Services/EnrolmentCertificateService.cs
@@ -25,12 +25,10 @@ namespace Prime.Services
             { "Plexia", "service@plexia.ca" }
         }.ToImmutableDictionary();
 
-        public EnrolmentCertificateService(
-            ApiDbContext context,
-            IHttpContextAccessor httpContext,
+        public EnrolmentCertificateService(IServiceProvider provider,
             IAccessTermService accessTermService,
             IEnrolleeProfileVersionService enroleeProfileVersionService)
-            : base(context, httpContext)
+            : base(provider)
         {
             _accessTermService = accessTermService;
             _enroleeProfileVersionService = enroleeProfileVersionService;

--- a/prime-dotnet-webapi/Services/LookupService.cs
+++ b/prime-dotnet-webapi/Services/LookupService.cs
@@ -12,10 +12,8 @@ namespace Prime.Services
 {
     public class LookupService : BaseService, ILookupService
     {
-        public LookupService(
-            ApiDbContext context,
-            IHttpContextAccessor httpContext)
-            : base(context, httpContext)
+        public LookupService(IServiceProvider provider)
+            : base(provider)
         { }
 
         public async Task<LookupEntity> GetLookupsAsync()

--- a/prime-dotnet-webapi/Services/PharmanetAPIService.cs
+++ b/prime-dotnet-webapi/Services/PharmanetAPIService.cs
@@ -19,10 +19,8 @@ namespace Prime.Services
     {
         private static HttpClient Client = InitHttpClient();
 
-        public PharmanetApiService(
-            ApiDbContext context,
-            IHttpContextAccessor httpContext)
-            : base(context, httpContext)
+        public PharmanetApiService(IServiceProvider provider)
+            : base(provider)
         { }
 
         private static HttpClient InitHttpClient()

--- a/prime-dotnet-webapi/Services/PrivilegeService.cs
+++ b/prime-dotnet-webapi/Services/PrivilegeService.cs
@@ -10,19 +10,17 @@ namespace Prime.Services
 {
     public class PrivilegeService : BaseService, IPrivilegeService
     {
-        public PrivilegeService(
-            ApiDbContext context,
-            IHttpContextAccessor httpContext)
-            : base(context, httpContext)
+        public PrivilegeService(IServiceProvider provider)
+            : base(provider)
         { }
 
         public async Task AssignPrivilegesToEnrolleeAsync(int enrolleeId, Enrollee enrollee)
         {
             var _enrolleeDb = _context.Enrollees
-                                .Include(e => e.Certifications)
-                                .Where(e => e.Id == enrollee.Id)
-                                .AsNoTracking()
-                                .SingleOrDefault();
+                .Include(e => e.Certifications)
+                .Where(e => e.Id == enrollee.Id)
+                .AsNoTracking()
+                .SingleOrDefault();
 
             ICollection<AssignedPrivilege> assignedPrivileges = await this.GetAssignedPrivilegesForEnrolleeAsync(enrolleeId);
 


### PR DESCRIPTION
Pulled the db context and http context into a common service provider. We can use this in the future to inject services used by every service (such as loggers) without having to add it to every service's constructor.

Currently breaks tests due to how we instantiate the service tests.