### PR TITLE
Add Missing OrgType Navigation Property

### DIFF
--- a/prime-dotnet-webapi/Models/SiteRegistration/Organization.cs
+++ b/prime-dotnet-webapi/Models/SiteRegistration/Organization.cs
@@ -26,8 +26,9 @@ namespace Prime.Models
 
         public int? OrganizationTypeCode { get; set; }
 
+        public OrganizationType OrganizationType { get; set; }
+
         [JsonIgnore]
         public IEnumerable<Location> Locations { get; set; }
-
     }
 }


### PR DESCRIPTION
Need the navigation property on Organization, it confuses Entity Framework without it (future migrations try to remove the foreign key).