### PR TITLE
PRIME-259 - BCeID

### DIFF
--- a/documentation/Keycloak settings/realm-export-dev.json
+++ b/documentation/Keycloak settings/realm-export-dev.json
@@ -345,6 +345,16 @@
           "attributes": {}
         }
       ],
+      "prime-document-management": [
+        {
+          "id": "51ed927d-f658-47b4-8fd9-114ca856b29e",
+          "name": "uma_protection",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "b539b23d-02df-4e3d-8a8a-30e31c80d4b8",
+          "attributes": {}
+        }
+      ],
       "prime-pos-gpid": [],
       "prime-careconnect-access": [],
       "security-admin-console": [],
@@ -1002,6 +1012,93 @@
       "defaultClientScopes": [
         "identity_provider",
         "identity_assurance_level"
+      ],
+      "optionalClientScopes": []
+    },
+    {
+      "id": "b539b23d-02df-4e3d-8a8a-30e31c80d4b8",
+      "clientId": "prime-document-management",
+      "description": "Service account used by the PRIME API to access the document manager",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "5157fc87-f96d-411d-bbbd-472b5542c29a",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "19849be5-32e6-48b5-8d47-2e937fab804f",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "b1951a9b-5713-4bce-b109-8b35fb74a880",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "roles"
       ],
       "optionalClientScopes": []
     },
@@ -1724,7 +1821,7 @@
       "displayName": "BCeID",
       "internalId": "3f486f0b-b153-43f0-888d-3fc4251b00a7",
       "providerId": "keycloak-oidc",
-      "enabled": false,
+      "enabled": true,
       "updateProfileFirstLoginMode": "on",
       "trustEmail": false,
       "storeToken": false,
@@ -1732,6 +1829,7 @@
       "authenticateByDefault": false,
       "linkOnly": false,
       "firstBrokerLoginFlowAlias": "first broker login",
+      "postBrokerLoginFlowAlias": "OTP challenge",
       "config": {
         "userInfoUrl": "https://sso-dev.pathfinder.gov.bc.ca/auth/realms/_bceid/protocol/openid-connect/userinfo",
         "validateSignature": "true",
@@ -1989,6 +2087,15 @@
       }
     },
     {
+      "id": "ebff01a7-4187-4d0d-8a84-25a473835299",
+      "name": "prime_user role",
+      "identityProviderAlias": "bceid",
+      "identityProviderMapper": "oidc-hardcoded-role-idp-mapper",
+      "config": {
+        "role": "prime_user"
+      }
+    },
+    {
       "id": "f3e447d1-ac07-4d64-92d6-e22fc86c2d88",
       "name": "email",
       "identityProviderAlias": "idir",
@@ -2217,6 +2324,23 @@
           "flowAlias": "Verify Existing Account by Re-authentication",
           "userSetupAllowed": false,
           "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "eb764830-71da-4fab-860d-72310630209d",
+      "alias": "OTP challenge",
+      "description": "An authentication flow based on challenge-response HTTP Authentication Schemes",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-otp-form",
+          "requirement": "REQUIRED",
+          "priority": 0,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
         }
       ]
     },

--- a/prime-dotnet-webapi/AuthConstants.cs
+++ b/prime-dotnet-webapi/AuthConstants.cs
@@ -8,10 +8,14 @@ namespace Prime.Auth
         public const string KEYCLOAK_ROLES_KEY = "roles";
         public const string KEYCLOAK_REALM_ACCESS_KEY = "realm_access";
         public const string KEYCLOAK_RESOURCE_ACCESS_KEY = "resource_access";
-        public const string ASSURANCE_LEVEL_CLAIM_TYPE = "identity_assurance_level";
         public readonly static string PRIME_ADMIN_CLIENT = Environment.GetEnvironmentVariable("JWT_ADMIN_CLIENT") ?? Startup.StaticConfig["Jwt:AdminClient"];
         public readonly static string PRIME_USER_CLIENT = Environment.GetEnvironmentVariable("JWT_USER_CLIENT") ?? Startup.StaticConfig["Jwt:UserClient"];
         public readonly static string[] PRIME_CLIENT_IDS = { PRIME_ADMIN_CLIENT, PRIME_USER_CLIENT };
+
+        // Claims
+        public const string ASSURANCE_LEVEL_CLAIM_TYPE = "identity_assurance_level";
+        public const string IDENTITY_PROVIDER_CLAIM_TYPE = "identity_provider";
+        public const string BC_SERVICES_CARD = "bcsc";
 
         // Roles
         public const string PRIME_SUPER_ADMIN_ROLE = "prime_super_admin";
@@ -20,7 +24,7 @@ namespace Prime.Auth
         public const string PRIME_READONLY_ADMIN = "prime_readonly_admin";
         public const string EXTERNAL_HPDID_ACCESS_ROLE = "external_hpdid_access";
 
-        // Features
+        // Feature Flags
         public const string FEATURE_SITE_REGISTRATION = "feature_site_registration";
 
         // Policies

--- a/prime-dotnet-webapi/AuthenticationSetup.cs
+++ b/prime-dotnet-webapi/AuthenticationSetup.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Security.Claims;
@@ -53,20 +54,8 @@ namespace Prime.Auth
                     options.RequireHttpsMetadata = false;
                 }
 
-                var audience = System.Environment.GetEnvironmentVariable("JWT_AUDIENCE");
-                if (audience == null)
-                {
-                    audience = configuration["Jwt:Audience"];
-                }
-
-                var wellKnownConfig = System.Environment.GetEnvironmentVariable("JWT_WELL_KNOWN_CONFIG");
-                if (wellKnownConfig == null)
-                {
-                    wellKnownConfig = configuration["Jwt:WellKnown"];
-                }
-
-                options.Audience = audience;
-                options.MetadataAddress = wellKnownConfig;
+                options.Audience = Environment.GetEnvironmentVariable("JWT_AUDIENCE") ?? configuration["Jwt:Audience"];
+                options.MetadataAddress = Environment.GetEnvironmentVariable("JWT_WELL_KNOWN_CONFIG") ?? configuration["Jwt:WellKnown"];
                 options.Events = new JwtBearerEvents
                 {
                     OnAuthenticationFailed = c =>

--- a/prime-dotnet-webapi/Configuration/StatusReasonConfiguration.cs
+++ b/prime-dotnet-webapi/Configuration/StatusReasonConfiguration.cs
@@ -23,6 +23,7 @@ namespace Prime.Configuration
                     new StatusReason { Code = 11, Name = "Contact Address or Identity Address not in British Columbia", CreatedTimeStamp = SEEDING_DATE, UpdatedTimeStamp = SEEDING_DATE },
                     new StatusReason { Code = 12, Name = "Admin has flagged the applicant for manual adjudication", CreatedTimeStamp = SEEDING_DATE, UpdatedTimeStamp = SEEDING_DATE },
                     new StatusReason { Code = 13, Name = "User does not have high enough identity assurance level", CreatedTimeStamp = SEEDING_DATE, UpdatedTimeStamp = SEEDING_DATE },
+                    new StatusReason { Code = 14, Name = "User authenticated with a method other than BC Services Card", CreatedTimeStamp = SEEDING_DATE, UpdatedTimeStamp = SEEDING_DATE },
                 };
             }
         }

--- a/prime-dotnet-webapi/Controllers/SubmissionsController.cs
+++ b/prime-dotnet-webapi/Controllers/SubmissionsController.cs
@@ -72,7 +72,9 @@ namespace Prime.Controllers
             }
 
             updatedProfile.IdentityAssuranceLevel = User.GetIdentityAssuranceLevel();
+            updatedProfile.IdentityProvider = User.GetIdentityProvider();
             await _submissionService.SubmitApplicationAsync(enrolleeId, updatedProfile);
+
             enrollee = await _enrolleeService.GetEnrolleeAsync(enrolleeId);
             return Ok(ApiResponse.Result(enrollee));
         }

--- a/prime-dotnet-webapi/Extensions/ClaimsPrincipalExtensions.cs
+++ b/prime-dotnet-webapi/Extensions/ClaimsPrincipalExtensions.cs
@@ -60,5 +60,11 @@ namespace Prime
             return assuranceLevel;
         }
 
+        public static string GetIdentityProvider(this ClaimsPrincipal User)
+        {
+            Claim identityProviderClaim = User?.Claims?.SingleOrDefault(c => c.Type == AuthConstants.IDENTITY_PROVIDER_CLAIM_TYPE);
+
+            return identityProviderClaim?.Value;
+        }
     }
 }

--- a/prime-dotnet-webapi/Infrastructure/PrimeUserAuthHandler.cs
+++ b/prime-dotnet-webapi/Infrastructure/PrimeUserAuthHandler.cs
@@ -16,8 +16,7 @@ namespace Prime.Infrastructure
             }
 
             if (context.User.HasAdminView()
-                || (context.User.IsInRole(AuthConstants.PRIME_ENROLLEE_ROLE)
-                    && context.User.GetIdentityAssuranceLevel() >= 2))
+                || context.User.IsInRole(AuthConstants.PRIME_ENROLLEE_ROLE))
             {
                 context.Succeed(requirement);
             }

--- a/prime-dotnet-webapi/Migrations/20200528235623_NonBcscStatusReason.Designer.cs
+++ b/prime-dotnet-webapi/Migrations/20200528235623_NonBcscStatusReason.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Prime;
@@ -10,9 +11,10 @@ using Prime.Models;
 namespace Prime.Migrations
 {
     [DbContext(typeof(ApiDbContext))]
-    partial class ApiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200528235623_NonBcscStatusReason")]
+    partial class NonBcscStatusReason
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/prime-dotnet-webapi/Migrations/20200528235623_NonBcscStatusReason.cs
+++ b/prime-dotnet-webapi/Migrations/20200528235623_NonBcscStatusReason.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Prime.Migrations
+{
+    public partial class NonBcscStatusReason : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "IdentityProvider",
+                table: "Enrollee",
+                nullable: true);
+
+            migrationBuilder.InsertData(
+                table: "StatusReasonLookup",
+                columns: new[] { "Code", "CreatedTimeStamp", "CreatedUserId", "Name", "UpdatedTimeStamp", "UpdatedUserId" },
+                values: new object[] { 14, new DateTimeOffset(new DateTime(2019, 9, 16, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, -7, 0, 0, 0)), new Guid("00000000-0000-0000-0000-000000000000"), "User authenticated with a method other than BC Services Card", new DateTimeOffset(new DateTime(2019, 9, 16, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, -7, 0, 0, 0)), new Guid("00000000-0000-0000-0000-000000000000") });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "StatusReasonLookup",
+                keyColumn: "Code",
+                keyValue: 14);
+
+            migrationBuilder.DropColumn(
+                name: "IdentityProvider",
+                table: "Enrollee");
+        }
+    }
+}

--- a/prime-dotnet-webapi/Models/Enrollee.cs
+++ b/prime-dotnet-webapi/Models/Enrollee.cs
@@ -119,6 +119,9 @@ namespace Prime.Models
         [JsonIgnore]
         public int IdentityAssuranceLevel { get; set; }
 
+        [JsonIgnore]
+        public string IdentityProvider { get; set; }
+
         [NotMapped]
         public EnrolmentStatus CurrentStatus
         {

--- a/prime-dotnet-webapi/Models/Statuses/StatusReasonType.cs
+++ b/prime-dotnet-webapi/Models/Statuses/StatusReasonType.cs
@@ -15,5 +15,6 @@ namespace Prime.Models
         Address = 11,
         AlwaysManual = 12,
         AssuranceLevel = 13,
+        IdentityProvider = 14,
     }
 }

--- a/prime-dotnet-webapi/Services/Rules/AutomaticAdjudicationRules.cs
+++ b/prime-dotnet-webapi/Services/Rules/AutomaticAdjudicationRules.cs
@@ -169,4 +169,18 @@ namespace Prime.Services.Rules
             return Task.FromResult(true);
         }
     }
+
+    public class IdentityProviderRule : AutomaticAdjudicationRule
+    {
+        public override Task<bool> ProcessRule(Enrollee enrollee)
+        {
+            if (enrollee.IdentityProvider != Auth.AuthConstants.BC_SERVICES_CARD)
+            {
+                enrollee.AddReasonToCurrentStatus(StatusReasonType.IdentityProvider, enrollee.IdentityProvider);
+                return Task.FromResult(false);
+            }
+
+            return Task.FromResult(true);
+        }
+    }
 }

--- a/prime-dotnet-webapi/Services/Rules/AutomaticAdjudicationRules.cs
+++ b/prime-dotnet-webapi/Services/Rules/AutomaticAdjudicationRules.cs
@@ -176,7 +176,7 @@ namespace Prime.Services.Rules
         {
             if (enrollee.IdentityProvider != Auth.AuthConstants.BC_SERVICES_CARD)
             {
-                enrollee.AddReasonToCurrentStatus(StatusReasonType.IdentityProvider, enrollee.IdentityProvider);
+                enrollee.AddReasonToCurrentStatus(StatusReasonType.IdentityProvider, $"Method used: {enrollee.IdentityProvider}");
                 return Task.FromResult(false);
             }
 

--- a/prime-dotnet-webapi/Services/SubmissionRulesService.cs
+++ b/prime-dotnet-webapi/Services/SubmissionRulesService.cs
@@ -41,7 +41,8 @@ namespace Prime.Services
                 // new DeviceProviderRule(),
                 new LicenceClassRule(),
                 new AlwaysManualRule(),
-                new IdentityAssuranceLevelRule()
+                new IdentityAssuranceLevelRule(),
+                new IdentityProviderRule()
             };
 
             return await ProcessRules(rules, enrollee);

--- a/prime-dotnet-webapi/ViewModels/Enrollee/EnrolleeProfileViewModel.cs
+++ b/prime-dotnet-webapi/ViewModels/Enrollee/EnrolleeProfileViewModel.cs
@@ -53,5 +53,9 @@ namespace Prime.ViewModels
         [JsonIgnore]
         // This property is set by the backend from the JWT token; we cannot trust this property from the frontend
         public int IdentityAssuranceLevel { get; set; }
+
+        [JsonIgnore]
+        // This property is set by the backend from the JWT token; we cannot trust this property from the frontend
+        public string IdentityProvider { get; set; }
     }
 }


### PR DESCRIPTION
BCeID has now been enabled in Dev only. BCeID requires two-factor authentication using GoogleAuth or FreeOTP (only FreeOTP ahs been tested). Currently, BCeIDs are automatically granted the prime_user role and have access to the application normally. A new auto-adjudication rule will flag any identity providers that are not BC Services Card to manual review (in addition to flagging any IDPs that have an assurance level of 2 or lower).

At this point, the assurance level requirement has been removed from our API's Auth policies, due to BCeID having an assurance level of 1.