### PR TITLE
PRIME-902 - Enrolment Certificate Bug

### DIFF
--- a/prime-dotnet-webapi/Models/EnrolmentCertificate.cs
+++ b/prime-dotnet-webapi/Models/EnrolmentCertificate.cs
@@ -18,9 +18,6 @@ namespace Prime.Models
 
         public static EnrolmentCertificate Create(Enrollee enrollee)
         {
-            // Display information from profile history from last submission before most recently accepted TOA
-            // Display GPID and Expiry Date from current enrollee object because inital submission will
-            // not have these fields until after accepting the TOA
             return new EnrolmentCertificate
             {
                 FirstName = enrollee.FirstName,

--- a/prime-dotnet-webapi/Models/EnrolmentCertificate.cs
+++ b/prime-dotnet-webapi/Models/EnrolmentCertificate.cs
@@ -12,29 +12,23 @@ namespace Prime.Models
         public string FirstName { get; set; }
         public string MiddleName { get; set; }
         public string LastName { get; set; }
-        public string PreferredFirstName { get; set; }
-        public string PreferredMiddleName { get; set; }
-        public string PreferredLastName { get; set; }
         public string GPID { get; set; }
         public DateTimeOffset? ExpiryDate { get; set; }
         public IEnumerable<OrganizationType> OrganizationTypes { get; set; }
 
-        public static EnrolmentCertificate Create(Enrollee enrolleeHistory, Enrollee enrollee)
+        public static EnrolmentCertificate Create(Enrollee enrollee)
         {
             // Display information from profile history from last submission before most recently accepted TOA
             // Display GPID and Expiry Date from current enrollee object because inital submission will
             // not have these fields until after accepting the TOA
             return new EnrolmentCertificate
             {
-                FirstName = enrolleeHistory.FirstName,
-                MiddleName = enrolleeHistory.MiddleName,
-                LastName = enrolleeHistory.LastName,
-                PreferredFirstName = enrolleeHistory.PreferredFirstName,
-                PreferredMiddleName = enrolleeHistory.PreferredMiddleName,
-                PreferredLastName = enrolleeHistory.PreferredLastName,
+                FirstName = enrollee.FirstName,
+                MiddleName = enrollee.MiddleName,
+                LastName = enrollee.LastName,
                 GPID = enrollee.GPID,
                 ExpiryDate = enrollee.ExpiryDate,
-                OrganizationTypes = enrolleeHistory.EnrolleeOrganizationTypes.Select(org => org.OrganizationType)
+                OrganizationTypes = enrollee.EnrolleeOrganizationTypes.Select(org => org.OrganizationType)
             };
         }
     }

--- a/prime-dotnet-webapi/Models/EnrolmentCertificate.cs
+++ b/prime-dotnet-webapi/Models/EnrolmentCertificate.cs
@@ -12,6 +12,9 @@ namespace Prime.Models
         public string FirstName { get; set; }
         public string MiddleName { get; set; }
         public string LastName { get; set; }
+        public string PreferredFirstName { get; set; }
+        public string PreferredMiddleName { get; set; }
+        public string PreferredLastName { get; set; }
         public string GPID { get; set; }
         public DateTimeOffset? ExpiryDate { get; set; }
         public IEnumerable<OrganizationType> OrganizationTypes { get; set; }
@@ -23,6 +26,9 @@ namespace Prime.Models
                 FirstName = enrollee.FirstName,
                 MiddleName = enrollee.MiddleName,
                 LastName = enrollee.LastName,
+                PreferredFirstName = enrollee.PreferredFirstName,
+                PreferredMiddleName = enrollee.PreferredMiddleName,
+                PreferredLastName = enrollee.PreferredLastName,
                 GPID = enrollee.GPID,
                 ExpiryDate = enrollee.ExpiryDate,
                 OrganizationTypes = enrollee.EnrolleeOrganizationTypes.Select(org => org.OrganizationType)

--- a/prime-dotnet-webapi/Services/EnrolmentCertificateService.cs
+++ b/prime-dotnet-webapi/Services/EnrolmentCertificateService.cs
@@ -35,7 +35,7 @@ namespace Prime.Services
 
             await UpdateTokenMetadataAsync(token);
 
-            if (token.Active && token.Enrollee.ExpiryDate != null)
+            if (token.Active)
             {
                 return EnrolmentCertificate.Create(token.Enrollee);
             }


### PR DESCRIPTION
The Enrollment Certificate link for provisioners failed due to the schema of the profile history changing, making it unable to find the organization types.

The decision was made to take the easy fix and let the organization types be "out of sync" with the application. When an enrollee re-submits their application, any change to organization types will be displayed immediately on the provisioner link while the application is under veview/awaiting TOA acceptance.