### PR TITLE
HOTFIX: Get Document Manager to actually deploy for real to Test and Prod

### DIFF
--- a/Jenkinsfile.promotion
+++ b/Jenkinsfile.promotion
@@ -26,6 +26,7 @@ pipeline {
                     // sh "./player.sh deploy mongo test -p SUFFIX=${SUFFIX}"
                     sh "./player.sh deploy api test ${API_ARGS} -p SUFFIX=${SUFFIX}"
                     sh "./player.sh deploy frontend test ${FRONTEND_ARGS} -p SUFFIX=${SUFFIX}"
+                    sh "./player.sh deploy document-manager test -p SUFFIX=${SUFFIX} -p VOLUME_CAPACITY=1Gi"
                     sh "./player.sh toolbelt schemaspy test"
                 }
             }
@@ -96,6 +97,7 @@ pipeline {
                             // sh "./player.sh deploy mongo test -p SUFFIX='-demo'"
                             sh "./player.sh deploy api test ${API_ARGS} -p SUFFIX='-demo'"
                             sh "./player.sh deploy frontend test ${FRONTEND_ARGS} -p SUFFIX='-demo'"
+                            sh "./player.sh deploy document-manager dev -p SUFFIX='-demo' -p VOLUME_CAPACITY=1Gi"                            
                         }
                     }
                 }
@@ -110,6 +112,7 @@ pipeline {
                             sh "./player.sh deploy postgres prod"
                             sh "./player.sh deploy api prod"
                             sh "./player.sh deploy frontend prod"
+                            sh "./player.sh deploy document-manager prod"
                             sh "./player.sh toolbelt schemaspy prod"
                         }
                     }


### PR DESCRIPTION
### Reason for hotfix
Document Manager was missing deploy commands in `Jenkinsfile.promotion`. So while it was able to be built, it did not deploy to test and prod.