### PR TITLE
FIX: Ensuring PVC claim is binded to pod volume

### DIFF
--- a/openshift/document-manager.dc.yaml
+++ b/openshift/document-manager.dc.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 labels:
   template: document-manager-template
 metadata:
-  name: document-manager-bc
+  name: document-manager-dc
   creationTimestamp: null
 parameters:
   - name: NAME

--- a/openshift/document-manager.dc.yaml
+++ b/openshift/document-manager.dc.yaml
@@ -190,7 +190,8 @@ objects:
         restartPolicy: Always
         volumes:
         - name: ${NAME}${SUFFIX}-pvc
-          emptyDir: {}
+          persistentVolumeClaim:
+            claimName: '${NAME}${SUFFIX}-pvc'
     test: false
     triggers:
     - type: ConfigChange


### PR DESCRIPTION
The Document Manager API, outside of PR branches, does not have its PVC claim binded to the pod volume. This means that with every deploy, we are wiping all storage. Additionally, we are not seeing equal replication between pods as a potential consequence of this behaviour.

This is being rectified by binding the PVC claim created for this service by binding it to the respective pod's volume.