### PR TITLE
1 MB File Upload Chunk Size

### DIFF
--- a/prime-angular-frontend/src/app/shared/components/document-upload/document-upload/document-upload.component.ts
+++ b/prime-angular-frontend/src/app/shared/components/document-upload/document-upload/document-upload.component.ts
@@ -82,6 +82,7 @@ export class DocumentUploadComponent implements OnInit {
         endpoint: `${environment.apiEndpoint}${this.apiSuffix}`,
         retryDelays: [0, 3000, 5000, 10000, 20000],
         metadata: { filename, filetype },
+        chunkSize: 1048576, // 1 MB
         headers: {
           'Access-Control-Allow-Origin': '*',
           Authorization: `Bearer ${token}`,


### PR DESCRIPTION
The frontend will now send file uploads in chunks of 1MB. This does not limit the size of the file upload, only the size of the data sent at once.

This could  be parameterized or made into an environment variable in the future, it's a hard-coded value for now.