### PR TITLE
FIX: Force Document Manager Migrate to wait for PostgreSQL deployment completion

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,7 +117,7 @@ services:
       - 6001:6001
     volumes:
       - ./document-manager/backend/:/app/
-#    command: /opt/app-root/src/app.sh dev
+    command: /opt/app-root/src/app.sh backend
     env_file: ./document-manager/backend/.env-prime-local
     networks:
       - primenet
@@ -131,7 +131,7 @@ services:
       - postgres
     volumes:
       - ./document-manager/backend/:/app/
-    command: flask db upgrade
+    command: /opt/app-root/src/app.sh migrate
     env_file: ./document-manager/backend/.env-prime-local
     networks:
       - primenet

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,7 +117,7 @@ services:
       - 6001:6001
     volumes:
       - ./document-manager/backend/:/app/
-    command: /opt/app-root/src/app.sh
+#    command: /opt/app-root/src/app.sh dev
     env_file: ./document-manager/backend/.env-prime-local
     networks:
       - primenet
@@ -126,7 +126,7 @@ services:
     restart: on-failure
     container_name: document-manager-migrate
     build:
-      context: document-manager/backend
+      context: document-manager/backend 
     depends_on:
       - postgres
     volumes:

--- a/document-manager/backend/Dockerfile
+++ b/document-manager/backend/Dockerfile
@@ -26,4 +26,5 @@ ENV DB_HOST postgresql${SUFFIX}
 ENV PGPASSWORD postgres
 # Run the server
 EXPOSE 5001 9191
-ENTRYPOINT /opt/app-root/src/app.sh dev
+#ENTRYPOINT /opt/app-root/src/app.sh dev
+# Entry remarked out, using command in compose instead

--- a/document-manager/backend/Dockerfile
+++ b/document-manager/backend/Dockerfile
@@ -23,6 +23,7 @@ RUN set -x && \
 WORKDIR ${APP_ROOT}/src
 ENV FLASK_APP app.py
 ENV DB_HOST postgresql${SUFFIX}
+ENV PGPASSWORD postgres
 # Run the server
 EXPOSE 5001 9191
 ENTRYPOINT /opt/app-root/src/app.sh dev

--- a/document-manager/backend/Dockerfile
+++ b/document-manager/backend/Dockerfile
@@ -25,5 +25,5 @@ WORKDIR ${APP_ROOT}/src
 ENV FLASK_APP app.py
 # Run the server
 EXPOSE 5001 9191
-ENTRYPOINT /opt/app-root/src/app.sh backend
+ENTRYPOINT /opt/app-root/src/app.sh dev
 #CMD ["flask","run"]

--- a/document-manager/backend/Dockerfile
+++ b/document-manager/backend/Dockerfile
@@ -15,7 +15,7 @@ COPY . .
 
 RUN set -x && \
     pip3 install --upgrade -U pip setuptools wheel && \
-    pip3 install psycopg2 && \
+    pip3 install psycopg2 postgres && \
     cd ${APP_ROOT}/src && \ 
     pip3 install -r requirements.txt
 #    source /opt/app-root/etc/scl_enable && \

--- a/document-manager/backend/Dockerfile
+++ b/document-manager/backend/Dockerfile
@@ -1,13 +1,11 @@
 FROM python:3.6
-ENV APP_ROOT /opt/app-root
-
-# Update installation utility
 USER 0
+ENV APP_ROOT /opt/app-root
+SHELL ["/bin/bash","-c"]
 # Update installation utility
 #RUN apt-get update
-SHELL ["/bin/bash","-c"]
 # Install project dependencies
-COPY . ${APP_ROOT}/src
+COPY . /opt/app-root/src
 
 # Install the requirements
 
@@ -18,16 +16,13 @@ RUN set -x && \
     pip3 install psycopg2 && \
     apt-get update -yqq && \
     apt-get install -yqq postgresql-client && \
-    cd ${APP_ROOT}/src && \ 
+    cd /opt/app-root/src && \ 
     pip3 install -r requirements.txt
-#    source /opt/app-root/etc/scl_enable && \
 
 # Create working directory
 WORKDIR ${APP_ROOT}/src
 ENV FLASK_APP app.py
-ENV DB_HOST primedb
-ENV PGPASSWORD postgres
+ENV DB_HOST postgresql${SUFFIX}
 # Run the server
 EXPOSE 5001 9191
 ENTRYPOINT /opt/app-root/src/app.sh dev
-#CMD ["flask","run"]

--- a/document-manager/backend/Dockerfile
+++ b/document-manager/backend/Dockerfile
@@ -15,7 +15,9 @@ COPY . .
 
 RUN set -x && \
     pip3 install --upgrade -U pip setuptools wheel && \
-    pip3 install psycopg2 postgres && \
+    pip3 install psycopg2 && \
+    apt-get update -yqq && \
+    apt-get install -yqq postgresql-client && \
     cd ${APP_ROOT}/src && \ 
     pip3 install -r requirements.txt
 #    source /opt/app-root/etc/scl_enable && \
@@ -23,6 +25,8 @@ RUN set -x && \
 # Create working directory
 WORKDIR ${APP_ROOT}/src
 ENV FLASK_APP app.py
+ENV DB_HOST primedb
+ENV PGPASSWORD postgres
 # Run the server
 EXPOSE 5001 9191
 ENTRYPOINT /opt/app-root/src/app.sh dev

--- a/document-manager/backend/Dockerfile
+++ b/document-manager/backend/Dockerfile
@@ -25,5 +25,5 @@ WORKDIR ${APP_ROOT}/src
 ENV FLASK_APP app.py
 # Run the server
 EXPOSE 5001 9191
-#ENTRYPOINT /opt/app-root/src/app.sh
+ENTRYPOINT /opt/app-root/src/app.sh backend
 #CMD ["flask","run"]

--- a/document-manager/backend/app.sh
+++ b/document-manager/backend/app.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 function waitForPsql() 
 {
-until  psql -h postgresql${SUFFIX} -U ${DB_USER} -d postgres -v QueryTimeout=1 -v ON_ERROR_STOP=1 -c "select version()" > /dev/null;
+until  psql -h $DB_HOST -U ${DB_USER} -d postgres -v QueryTimeout=1 -v ON_ERROR_STOP=1 -c "select version()" > /dev/null;
 do
     echo "waiting for postgres container..."
     sleep 2

--- a/document-manager/backend/app.sh
+++ b/document-manager/backend/app.sh
@@ -28,6 +28,10 @@ case "$1" in
     migrate)
         migrate
         ;;
+    dev)
+        migrate
+        backend
+        ;;
     *)
     echo "You\'re doing it wrong..."
 esac

--- a/document-manager/backend/app.sh
+++ b/document-manager/backend/app.sh
@@ -1,4 +1,33 @@
 #!/bin/bash
-cd /opt/app-root/src
-flask run ${FLASK_RUN_PARAMS} &disown 
-uwsgi uwsgi.ini
+function waitForPsql() 
+{
+until  psql -h postgresql${SUFFIX} -U ${DB_USER} -d postgres -v QueryTimeout=1 -v ON_ERROR_STOP=1 -c "select version()" > /dev/null;
+do
+    echo "waiting for postgres container..."
+    sleep 2
+done
+}
+
+function backend()
+{
+    waitForPsql
+    cd /opt/app-root/src
+    flask run ${FLASK_RUN_PARAMS} &disown 
+    uwsgi uwsgi.ini
+}
+
+function migrate()
+{
+    waitForPsql
+    flask db upgrade ${FLASK_RUN_PARAMS}
+}
+case "$1" in
+    backend)
+        backend
+        ;;
+    migrate)
+        migrate
+        ;;
+    *)
+    echo "You\'re doing it wrong..."
+esac

--- a/document-manager/backend/openshift.dockerfile
+++ b/document-manager/backend/openshift.dockerfile
@@ -13,7 +13,6 @@ COPY . .
 RUN set -x && \
     pip3 install --upgrade -U pip setuptools wheel && \
     pip3 install psycopg2 && \
-    yum update -y && \
     yum install -y postgresql-client && \
     source /opt/app-root/etc/scl_enable && \
     cd ${APP_ROOT}/src && \ 

--- a/document-manager/backend/openshift.dockerfile
+++ b/document-manager/backend/openshift.dockerfile
@@ -1,4 +1,4 @@
-FROM docker-registry.default.svc:5000/dqszvc-tools/python-36-rhel7:1-36
+FROM docker-registry.default.svc:5000/dqszvc-tools/python:3.6
 USER 0
 SHELL ["/bin/bash","-c"]
 # Update installation utility
@@ -13,7 +13,8 @@ COPY . .
 RUN set -x && \
     pip3 install --upgrade -U pip setuptools wheel && \
     pip3 install psycopg2 && \
-    yum install -y postgresql-client && \
+    apt-get update -yqq && \
+    apt-get install -yqq postgresql-client && \
     source /opt/app-root/etc/scl_enable && \
     cd ${APP_ROOT}/src && \ 
     pip3 install -r requirements.txt

--- a/document-manager/backend/openshift.dockerfile
+++ b/document-manager/backend/openshift.dockerfile
@@ -12,7 +12,9 @@ COPY . .
 
 RUN set -x && \
     pip3 install --upgrade -U pip setuptools wheel && \
-    pip3 install psycopg2 postgres && \
+    pip3 install psycopg2 && \
+    apt-get update -yqq && \
+    apt-get install -yqq postgresql-client && \
     source /opt/app-root/etc/scl_enable && \
     cd ${APP_ROOT}/src && \ 
     pip3 install -r requirements.txt
@@ -20,6 +22,8 @@ RUN set -x && \
 # Create working directory
 WORKDIR ${APP_ROOT}/src
 ENV FLASK_APP app.py
+ENV SUFFIX $SUFFIX
+ENV DB_HOST postgresql$SUFFIX
 # Run the server
 EXPOSE 5001 9191
 ENTRYPOINT /opt/app-root/src/app.sh backend

--- a/document-manager/backend/openshift.dockerfile
+++ b/document-manager/backend/openshift.dockerfile
@@ -16,6 +16,7 @@ RUN set -x && \
     pip3 install psycopg2 && \
     apt-get update -yqq && \
     apt-get install -yqq postgresql-client && \
+    find / -type f -name scl_enable && \
     source /opt/app-root/etc/scl_enable && \
     cd /opt/app-root/src && \ 
     pip3 install -r requirements.txt

--- a/document-manager/backend/openshift.dockerfile
+++ b/document-manager/backend/openshift.dockerfile
@@ -22,8 +22,7 @@ RUN set -x && \
 # Create working directory
 WORKDIR ${APP_ROOT}/src
 ENV FLASK_APP app.py
-ENV SUFFIX $SUFFIX
-ENV DB_HOST postgresql$SUFFIX
+ENV DB_HOST postgresql${SUFFIX}
 # Run the server
 EXPOSE 5001 9191
 ENTRYPOINT /opt/app-root/src/app.sh backend

--- a/document-manager/backend/openshift.dockerfile
+++ b/document-manager/backend/openshift.dockerfile
@@ -1,5 +1,6 @@
 FROM docker-registry.default.svc:5000/dqszvc-tools/python:3.6
 USER 0
+ENV APP_ROOT /opt/app-root
 SHELL ["/bin/bash","-c"]
 # Update installation utility
 #RUN apt-get update

--- a/document-manager/backend/openshift.dockerfile
+++ b/document-manager/backend/openshift.dockerfile
@@ -5,7 +5,7 @@ SHELL ["/bin/bash","-c"]
 # Update installation utility
 #RUN apt-get update
 # Install project dependencies
-COPY . ${APP_ROOT}/src
+COPY . /opt/app-root/src
 
 # Install the requirements
 
@@ -17,7 +17,7 @@ RUN set -x && \
     apt-get update -yqq && \
     apt-get install -yqq postgresql-client && \
     source /opt/app-root/etc/scl_enable && \
-    cd ${APP_ROOT}/src && \ 
+    cd /opt/app-root/src && \ 
     pip3 install -r requirements.txt
 
 # Create working directory

--- a/document-manager/backend/openshift.dockerfile
+++ b/document-manager/backend/openshift.dockerfile
@@ -12,7 +12,7 @@ COPY . .
 
 RUN set -x && \
     pip3 install --upgrade -U pip setuptools wheel && \
-    pip3 install psycopg2 && \
+    pip3 install psycopg2 postgres && \
     source /opt/app-root/etc/scl_enable && \
     cd ${APP_ROOT}/src && \ 
     pip3 install -r requirements.txt

--- a/document-manager/backend/openshift.dockerfile
+++ b/document-manager/backend/openshift.dockerfile
@@ -16,8 +16,6 @@ RUN set -x && \
     pip3 install psycopg2 && \
     apt-get update -yqq && \
     apt-get install -yqq postgresql-client && \
-    find / -type f -name scl_enable && \
-    source /opt/app-root/etc/scl_enable && \
     cd /opt/app-root/src && \ 
     pip3 install -r requirements.txt
 

--- a/document-manager/backend/openshift.dockerfile
+++ b/document-manager/backend/openshift.dockerfile
@@ -13,8 +13,8 @@ COPY . .
 RUN set -x && \
     pip3 install --upgrade -U pip setuptools wheel && \
     pip3 install psycopg2 && \
-    apt-get update -yqq && \
-    apt-get install -yqq postgresql-client && \
+    yum update -y && \
+    yum install -y postgresql-client && \
     source /opt/app-root/etc/scl_enable && \
     cd ${APP_ROOT}/src && \ 
     pip3 install -r requirements.txt

--- a/document-manager/backend/openshift.dockerfile
+++ b/document-manager/backend/openshift.dockerfile
@@ -22,4 +22,4 @@ WORKDIR ${APP_ROOT}/src
 ENV FLASK_APP app.py
 # Run the server
 EXPOSE 5001 9191
-ENTRYPOINT /opt/app-root/src/app.sh
+ENTRYPOINT /opt/app-root/src/app.sh backend

--- a/document-manager/backend/requirements.txt
+++ b/document-manager/backend/requirements.txt
@@ -21,3 +21,4 @@ SQLAlchemy==1.3.4
 uwsgi==2.0.18
 uwsgitop==0.11
 Werkzeug==0.15.4
+postgres

--- a/document-manager/backend/requirements.txt
+++ b/document-manager/backend/requirements.txt
@@ -9,6 +9,7 @@ Flask-Migrate==2.5.2
 flask-restplus==0.12.1
 Flask-SQLAlchemy==2.4.0
 flask_jwt_oidc==0.1.5
+postgres==3.0.0
 psycopg2==2.8.2
 psycopg2-binary==2.8.2
 pytest==4.5.0
@@ -21,4 +22,3 @@ SQLAlchemy==1.3.4
 uwsgi==2.0.18
 uwsgitop==0.11
 Werkzeug==0.15.4
-postgres

--- a/openshift/document-manager-ephemeral.dc.yaml
+++ b/openshift/document-manager-ephemeral.dc.yaml
@@ -206,10 +206,8 @@ objects:
     restartPolicy: Never
     containers:
     - command:
-        - /bin/bash
-      args: 
-        - '-c'
         - /opt/app-root/src/app.sh
+      args: 
         - migrate
       env:
         - name: CACHE_REDIS_HOST

--- a/openshift/document-manager-ephemeral.dc.yaml
+++ b/openshift/document-manager-ephemeral.dc.yaml
@@ -164,6 +164,11 @@ objects:
               secretKeyRef:
                 key: JWT_WELL_KNOWN_CONFIG
                 name: "keycloak"
+          - name: PGPASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: database-admin-password
+                name: 'postgresql-secret'
           image: " "
           name: document-manager-backend
           ports:
@@ -200,6 +205,8 @@ objects:
   spec:
     restartPolicy: Never
     containers:
+    - command:
+        - /
     - command:
         - flask
       args: 
@@ -279,8 +286,8 @@ objects:
         - name: PGPASSWORD
           valueFrom:
             secretKeyRef:
-              key: pg-password
-              name: '${NAME}-secret'
+              key: database-admin-password
+              name: 'postgresql-secret'
       image: docker-registry.default.svc:5000/${OC_NAMESPACE}-${OC_APP}/${NAME}${SUFFIX}:latest
       name: ${NAME}${SUFFIX}-migrate
       resources: {}

--- a/openshift/document-manager-ephemeral.dc.yaml
+++ b/openshift/document-manager-ephemeral.dc.yaml
@@ -276,6 +276,11 @@ objects:
             secretKeyRef:
               key: JWT_WELL_KNOWN_CONFIG
               name: "keycloak"
+        - name: PGPASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: pg-password
+              name: '${NAME}-secret'
       image: docker-registry.default.svc:5000/${OC_NAMESPACE}-${OC_APP}/${NAME}${SUFFIX}:latest
       name: ${NAME}${SUFFIX}-migrate
       resources: {}

--- a/openshift/document-manager-ephemeral.dc.yaml
+++ b/openshift/document-manager-ephemeral.dc.yaml
@@ -206,12 +206,11 @@ objects:
     restartPolicy: Never
     containers:
     - command:
-        - /
-    - command:
-        - flask
+        - /bin/bash
       args: 
-        - db
-        - upgrade
+        - '-c'
+        - /opt/app-root/src/app.sh
+        - migrate
       env:
         - name: CACHE_REDIS_HOST
           value: "redis${SUFFIX}"

--- a/openshift/document-manager.dc.yaml
+++ b/openshift/document-manager.dc.yaml
@@ -221,10 +221,8 @@ objects:
     restartPolicy: Never
     containers:
     - command:
-        - /bin/bash
-      args: 
-        - '-c'
         - /opt/app-root/src/app.sh
+      args: 
         - migrate
       env:
         - name: CACHE_REDIS_HOST

--- a/openshift/document-manager.dc.yaml
+++ b/openshift/document-manager.dc.yaml
@@ -181,8 +181,8 @@ objects:
           - name: PGPASSWORD
             valueFrom:
               secretKeyRef:
-                key: pg-password
-                name: '${NAME}-secret'
+                key: database-admin-password
+                name: 'postgresql-secret'
           image: " "
           name: document-manager-backend
           ports:
@@ -299,8 +299,8 @@ objects:
         - name: PGPASSWORD
           valueFrom:
             secretKeyRef:
-              key: pg-password
-              name: '${NAME}-secret'
+              key: database-admin-password
+              name: 'postgresql-secret'
       image: docker-registry.default.svc:5000/${OC_NAMESPACE}-${OC_APP}/${NAME}${SUFFIX}:latest
       name: ${NAME}${SUFFIX}-migrate
       resources: {}

--- a/openshift/document-manager.dc.yaml
+++ b/openshift/document-manager.dc.yaml
@@ -221,10 +221,11 @@ objects:
     restartPolicy: Never
     containers:
     - command:
-        - flask
-      args:
-        - db
-        - upgrade
+        - /bin/bash
+      args: 
+        - '-c'
+        - /opt/app-root/src/app.sh
+        - migrate
       env:
         - name: CACHE_REDIS_HOST
           value: "redis${SUFFIX}"

--- a/openshift/document-manager.dc.yaml
+++ b/openshift/document-manager.dc.yaml
@@ -178,6 +178,11 @@ objects:
               secretKeyRef:
                 key: JWT_WELL_KNOWN_CONFIG
                 name: "keycloak"
+          - name: PGPASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: pg-password
+                name: '${NAME}-secret'
           image: " "
           name: document-manager-backend
           ports:
@@ -291,6 +296,11 @@ objects:
             secretKeyRef:
               key: JWT_WELL_KNOWN_CONFIG
               name: "keycloak"
+        - name: PGPASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: pg-password
+              name: '${NAME}-secret'
       image: docker-registry.default.svc:5000/${OC_NAMESPACE}-${OC_APP}/${NAME}${SUFFIX}:latest
       name: ${NAME}${SUFFIX}-migrate
       resources: {}

--- a/openshift/postgresql.dc.yaml
+++ b/openshift/postgresql.dc.yaml
@@ -143,6 +143,11 @@ objects:
           containers:
             - capabilities: {}
               env:
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      key: pg-password
+                      name: '${NAME}-secret'
                 - name: POSTGRESQL_USER
                   valueFrom:
                     secretKeyRef:

--- a/openshift/postgresql.dc.yaml
+++ b/openshift/postgresql.dc.yaml
@@ -146,7 +146,7 @@ objects:
                 - name: PGPASSWORD
                   valueFrom:
                     secretKeyRef:
-                      key: pg-password
+                      key: database-admin-password
                       name: '${NAME}-secret'
                 - name: POSTGRESQL_USER
                   valueFrom:

--- a/openshift/postgresql.ephemeral.dc.yaml
+++ b/openshift/postgresql.ephemeral.dc.yaml
@@ -131,6 +131,11 @@ objects:
           containers:
             - capabilities: {}
               env:
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      key: pg-password
+                      name: '${NAME}-secret'
                 - name: POSTGRESQL_USER
                   valueFrom:
                     secretKeyRef:

--- a/openshift/postgresql.ephemeral.dc.yaml
+++ b/openshift/postgresql.ephemeral.dc.yaml
@@ -134,7 +134,7 @@ objects:
                 - name: PGPASSWORD
                   valueFrom:
                     secretKeyRef:
-                      key: pg-password
+                      key: database-admin-password
                       name: '${NAME}-secret'
                 - name: POSTGRESQL_USER
                   valueFrom:


### PR DESCRIPTION
## What's New
Force Document Manager migrate pod to wait for PostgreSQL to finish deploying, avoiding a race condition where the migrate pod will attempt to run before PostgreSQL becomes available.