### PR TITLE
Remove Privileges

### DIFF
--- a/prime-angular-frontend/src/app/modules/enrolment/pages/pharmanet-enrolment-summary/pharmanet-enrolment-summary.component.ts
+++ b/prime-angular-frontend/src/app/modules/enrolment/pages/pharmanet-enrolment-summary/pharmanet-enrolment-summary.component.ts
@@ -54,10 +54,6 @@ export class PharmanetEnrolmentSummaryComponent extends BaseEnrolmentPage implem
     return (this.enrollee) ? this.enrollee.mailingAddress : null;
   }
 
-  public get privileges() {
-    return (this.enrolment) ? this.enrolment.privileges : null;
-  }
-
   public get careSettings() {
     return (this.enrolment) ? this.enrolment.careSettings : null;
   }

--- a/prime-angular-frontend/src/app/shared/models/enrolment.model.ts
+++ b/prime-angular-frontend/src/app/shared/models/enrolment.model.ts
@@ -26,7 +26,6 @@ export interface HttpEnrollee extends Enrollee {
   selfDeclarations: SelfDeclaration[];
   selfDeclarationDocuments: SelfDeclarationDocument[];
   enrolleeCareSettings: CareSetting[];
-  privileges: Privilege[];
   enrolmentStatuses: EnrolmentStatus[];
   currentStatus: EnrolmentStatus;
   previousStatus: EnrolmentStatus;
@@ -64,7 +63,6 @@ export interface Enrolment {
   selfDeclarations: SelfDeclaration[];
   selfDeclarationDocuments: SelfDeclarationDocument[];
   careSettings: CareSetting[];
-  privileges: Privilege[];
   enrolmentStatuses: EnrolmentStatus[];
   currentStatus: EnrolmentStatus;
   previousStatus: EnrolmentStatus;

--- a/prime-angular-frontend/src/test/mocks/mock-enrolment.service.ts
+++ b/prime-angular-frontend/src/test/mocks/mock-enrolment.service.ts
@@ -51,7 +51,6 @@ export class MockEnrolmentService implements IEnrolmentService {
           careSettingCode: 1
         }
       ],
-      privileges: [],
       enrolmentStatuses: null,
       currentStatus: {
         id: faker.random.number(),

--- a/prime-dotnet-webapi-tests/ModelFactories/EnrolleeFactory.cs
+++ b/prime-dotnet-webapi-tests/ModelFactories/EnrolleeFactory.cs
@@ -48,7 +48,6 @@ namespace PrimeTests.ModelFactories
             RuleFor(x => x.AccessAgreementNote, f => null);
             RuleFor(x => x.AdjudicatorNotes, (f, x) => new AdjudicatorNoteFactory(x).GenerateBetween(1, 4).OrNull(f));
             RuleFor(x => x.AssignedPrivileges, f => null);
-            RuleFor(x => x.Privileges, f => null);
             RuleFor(x => x.EnrolleeProfileVersions, f => null);
             RuleFor(x => x.isAdminView, f => true);
             RuleFor(x => x.RequestingRemoteAccess, f => false);
@@ -97,7 +96,6 @@ namespace PrimeTests.ModelFactories
                             .Distinct()
                             .Select(privilegeId => new AssignedPrivilegeFactory(x, privilegeId).Generate())
                             .ToList();
-                        x.Privileges = x.AssignedPrivileges.Select(p => p.Privilege).ToList();
                     }
                 }
             });

--- a/prime-dotnet-webapi/Models/Enrollee.cs
+++ b/prime-dotnet-webapi/Models/Enrollee.cs
@@ -70,9 +70,6 @@ namespace Prime.Models
         [JsonIgnore]
         public ICollection<AssignedPrivilege> AssignedPrivileges { get; set; }
 
-        [NotMapped]
-        public ICollection<Privilege> Privileges { get; set; }
-
         public ICollection<EnrolmentStatus> EnrolmentStatuses { get; set; }
 
         [NotMapped]

--- a/prime-dotnet-webapi/Services/EnrolleeService.cs
+++ b/prime-dotnet-webapi/Services/EnrolleeService.cs
@@ -55,15 +55,8 @@ namespace Prime.Services
 
         public async Task<Enrollee> GetEnrolleeAsync(Guid userId)
         {
-            var entity = await this.GetBaseEnrolleeQuery()
+            return await this.GetBaseEnrolleeQuery()
                 .SingleOrDefaultAsync(e => e.UserId == userId);
-
-            if (entity != null)
-            {
-                entity.Privileges = await _privilegeService.GetPrivilegesForEnrolleeAsync(entity);
-            }
-
-            return entity;
         }
 
         public async Task<Enrollee> GetEnrolleeAsync(int enrolleeId, bool isAdmin = false)
@@ -86,8 +79,6 @@ namespace Prime.Services
 
             if (entity != null)
             {
-                entity.Privileges = await _privilegeService.GetPrivilegesForEnrolleeAsync(entity);
-
                 // TODO: This is an interm fix for making a different view model for enrollee based on isAdmin
                 if (isAdmin)
                 {
@@ -126,11 +117,6 @@ namespace Prime.Services
                 items = items.Where(e => e.CurrentStatus.StatusCode == searchOptions.StatusCode);
             }
 
-            foreach (var item in items)
-            {
-                item.Privileges = await _privilegeService.GetPrivilegesForEnrolleeAsync(item);
-            }
-
             return items;
         }
 
@@ -145,7 +131,6 @@ namespace Prime.Services
                 return null;
             }
 
-            enrollee.Privileges = await _privilegeService.GetPrivilegesForEnrolleeAsync(enrollee);
             return enrollee;
         }
 
@@ -304,11 +289,6 @@ namespace Prime.Services
             var entity = await this.GetBaseEnrolleeQuery()
                 .AsNoTracking()
                 .SingleOrDefaultAsync(e => e.Id == enrolleeId);
-
-            if (entity != null)
-            {
-                entity.Privileges = await _privilegeService.GetPrivilegesForEnrolleeAsync(entity);
-            }
 
             return entity;
         }

--- a/prime-dotnet-webapi/Services/EnrolleeService.cs
+++ b/prime-dotnet-webapi/Services/EnrolleeService.cs
@@ -14,7 +14,6 @@ namespace Prime.Services
     {
         private readonly ISubmissionRulesService _automaticAdjudicationService;
         private readonly IEmailService _emailService;
-        private readonly IPrivilegeService _privilegeService;
         private readonly IEnrolleeProfileVersionService _enroleeProfileVersionService;
         private readonly IBusinessEventService _businessEventService;
 
@@ -23,14 +22,12 @@ namespace Prime.Services
             IHttpContextAccessor httpContext,
             ISubmissionRulesService automaticAdjudicationService,
             IEmailService emailService,
-            IPrivilegeService privilegeService,
             IEnrolleeProfileVersionService enroleeProfileVersionService,
             IBusinessEventService businessEventService)
             : base(context, httpContext)
         {
             _automaticAdjudicationService = automaticAdjudicationService;
             _emailService = emailService;
-            _privilegeService = privilegeService;
             _enroleeProfileVersionService = enroleeProfileVersionService;
             _businessEventService = businessEventService;
         }

--- a/prime-dotnet-webapi/Services/PrivilegeService.cs
+++ b/prime-dotnet-webapi/Services/PrivilegeService.cs
@@ -67,7 +67,6 @@ namespace Prime.Services
                     }
                 }
 
-                _enrolleeDb.Privileges = await this.GetPrivilegesForEnrolleeAsync(enrollee);
                 _context.Entry(_enrolleeDb).State = EntityState.Modified;
 
                 await _context.SaveChangesAsync();


### PR DESCRIPTION
Privileges on Enrollees is not used or displayed currently and requires extra database hits to populate.

This PR is to remove the Privileges property in a single PR so it can be reverted later if need be.