### PR TITLE
PRIME-907 - Fix Minor Update Rule

### DIFF
--- a/prime-dotnet-webapi-tests/Extensions/EnrolleeExtensions.cs
+++ b/prime-dotnet-webapi-tests/Extensions/EnrolleeExtensions.cs
@@ -11,7 +11,7 @@ namespace PrimeTests
 {
     public static class EnrolleeExtensions
     {
-        public static EnrolleeUpdateModel ToViewModel(this Enrollee enrollee)
+        public static EnrolleeUpdateModel ToUpdateModel(this Enrollee enrollee)
         {
             JsonSerializerSettings settings = new JsonSerializerSettings
             {

--- a/prime-dotnet-webapi/Services/Rules/MinorUpdateRules.cs
+++ b/prime-dotnet-webapi/Services/Rules/MinorUpdateRules.cs
@@ -97,11 +97,6 @@ namespace Prime.Services.Rules
                 return Task.FromResult(false);
             }
 
-            if (!CompareCollections(comparitor, enrollee.SelfDeclarationDocuments, _updatedProfile.SelfDeclarationDocuments))
-            {
-                return Task.FromResult(false);
-            }
-
             return Task.FromResult(true);
         }
 
@@ -153,11 +148,6 @@ namespace Prime.Services.Rules
             config.IgnoreProperty<SelfDeclaration>(x => x.SelfDeclarationType);
             config.IgnoreProperty<SelfDeclaration>(x => x.EnrolleeId);
             config.IgnoreProperty<SelfDeclaration>(x => x.Enrollee);
-
-            config.IgnoreProperty<SelfDeclarationDocument>(x => x.Id);
-            config.IgnoreProperty<SelfDeclarationDocument>(x => x.SelfDeclarationType);
-            config.IgnoreProperty<SelfDeclarationDocument>(x => x.EnrolleeId);
-            config.IgnoreProperty<SelfDeclarationDocument>(x => x.Enrollee);
 
             return new CompareLogic(config);
         }

--- a/prime-dotnet-webapi/Services/SubmissionService.cs
+++ b/prime-dotnet-webapi/Services/SubmissionService.cs
@@ -59,6 +59,7 @@ namespace Prime.Services
                 .Include(e => e.Jobs)
                 .Include(e => e.EnrolleeCareSettings)
                 .Include(e => e.AccessTerms)
+                .Include(e => e.SelfDeclarations)
                 .SingleOrDefaultAsync(e => e.Id == enrolleeId);
 
             bool minorUpdate = await _submissionRulesService.QualifiesAsMinorUpdateAsync(enrollee, updatedProfile);

--- a/prime-dotnet-webapi/ViewModels/Enrollee/EnrolleeUpdateModel.cs
+++ b/prime-dotnet-webapi/ViewModels/Enrollee/EnrolleeUpdateModel.cs
@@ -36,8 +36,6 @@ namespace Prime.ViewModels
 
         public ICollection<SelfDeclaration> SelfDeclarations { get; set; }
 
-        public ICollection<SelfDeclarationDocument> SelfDeclarationDocuments { get; set; }
-
         [JsonIgnore]
         // This property is set by the backend from the JWT token; we cannot trust this property from the frontend
         public int IdentityAssuranceLevel { get; set; }


### PR DESCRIPTION
Minor update rule now correctly behaves again. However, we cannot currently tell if new self declaration documents are uploaded to an existing self declaration due to the documents being uploaded outside of the submission of a new profile. See https://bcgovmoh.atlassian.net/browse/PRIME-1023.