### PR TITLE
PRIME-1025 - File Upload Label Includes Allowed File Types

### DIFF
--- a/prime-angular-frontend/src/app/shared/components/document-upload/document-upload/document-upload.component.ts
+++ b/prime-angular-frontend/src/app/shared/components/document-upload/document-upload/document-upload.component.ts
@@ -54,7 +54,7 @@ export class DocumentUploadComponent implements OnInit {
 
     this.filePondOptions = {
       className: `prime-filepond-${this.componentName}`,
-      labelIdle: 'Click to Browse or Drop files here',
+      labelIdle: this.getIdleText(fileValidateTypeLabelExpectedTypesMap),
       fileValidateTypeLabelExpectedTypesMap,
       acceptedFileTypes: Object.keys(fileValidateTypeLabelExpectedTypesMap),
       allowFileTypeValidation: true,
@@ -63,7 +63,7 @@ export class DocumentUploadComponent implements OnInit {
       maxTotalFileSize: null,
       server: this.constructServer()
     };
-    
+
     if (this.additionalApiSuffix) {
       this.apiSuffix = `${this.apiSuffix}/${this.additionalApiSuffix}`;
     }
@@ -76,6 +76,23 @@ export class DocumentUploadComponent implements OnInit {
   public async onFilePondAddFile() {
     // Can't get token synchronously inside server.process(), so refresh token on file add.
     this.jwt = await this.keycloakTokenService.token();
+  }
+
+  private getIdleText(allowedFileTypesMap: { [key: string]: string }): string {
+    const baseText = 'Click to Browse or Drop files here.';
+    if (allowedFileTypesMap == null) {
+      return baseText;
+    }
+
+    const types = Object.values(allowedFileTypesMap);
+    let typeText = types.pop();
+
+    if (types.length > 0) {
+      const allButLast = types.join(', ');
+      typeText = `${allButLast} or ${typeText}`;
+    }
+
+    return `${baseText} Files must be ${typeText}`;
   }
 
   private constructServer() {

--- a/prime-angular-frontend/src/app/shared/components/document-upload/document-upload/document-upload.component.ts
+++ b/prime-angular-frontend/src/app/shared/components/document-upload/document-upload/document-upload.component.ts
@@ -79,7 +79,7 @@ export class DocumentUploadComponent implements OnInit {
   }
 
   private getIdleText(allowedFileTypesMap: { [key: string]: string }): string {
-    const baseText = 'Click to Browse or Drop files here.';
+    const baseText = 'Click to Browse or Drop files here';
     if (allowedFileTypesMap == null) {
       return baseText;
     }
@@ -92,7 +92,7 @@ export class DocumentUploadComponent implements OnInit {
       typeText = `${allButLast} or ${typeText}`;
     }
 
-    return `${baseText} Files must be ${typeText}`;
+    return `${baseText}. Files must be ${typeText}`;
   }
 
   private constructServer() {


### PR DESCRIPTION
First (smaller) part of ticket 851 adds the allowed file types to the idle label of Filepond. Should handle any list of allowed file types, and does not have any extra text if no allowed filetypes are supplied (in case we allow all file types in the future somewhere).