### PR TITLE
Add temporary PHSA eForms URL

### DIFF
--- a/openshift/angular-frontend.dc.yaml
+++ b/openshift/angular-frontend.dc.yaml
@@ -97,6 +97,7 @@ objects:
           ports:
           - containerPort: 8080
           - containerPort: 8443
+          - containerPort: 8888
           readinessProbe:
             failureThreshold: 3
             httpGet:
@@ -129,7 +130,7 @@ objects:
         type: ImageChange
   status: {}
 
-# Angular route definition to direct external traffic to frontend component
+# Route definition to direct external traffic via Pharmanet Enrolment URL
 - apiVersion: v1
   kind: Route
   metadata:
@@ -141,6 +142,22 @@ objects:
     tls:
         insecureEdgeTerminationPolicy: Redirect
         termination: passthrough
+    to:
+      kind: Service
+      name: "${NAME}${SUFFIX}"
+
+# Route definition to direct external traffic via PHSA eForms URL
+- apiVersion: v1
+  kind: Route
+  metadata:
+    name: "${NAME}${SUFFIX}-hrp"
+  spec:
+    host: "healthpractionerregistration${SUFFIX}.pathfinder.gov.bc.ca"
+    port:
+      targetPort: "8888"
+    tls:
+        insecureEdgeTerminationPolicy: Allow
+        termination: edge
     to:
       kind: Service
       name: "${NAME}${SUFFIX}"
@@ -161,6 +178,9 @@ objects:
     - name: "8443"
       port: 8443
       targetPort: 8443
+    - name: "8888"
+      port: 8888
+      targetPort: 8888
     selector:
       io.kompose.service: "${NAME}${SUFFIX}"
   status:

--- a/prime-angular-frontend/nginx.template.conf
+++ b/prime-angular-frontend/nginx.template.conf
@@ -41,3 +41,31 @@ server {
     }
 
 }
+server {
+    listen              8888 ssl;
+    server_name         *.gov.bc.ca;
+    server_tokens off;
+    root   /usr/share/nginx/html;
+    index  index.html index.htm;
+    include /etc/nginx/mime.types;
+    add_header X-Frame-Options "ALLOW-FROM dev.oidc.gov.bc.ca" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Content-Security-Policy "frame-ancestors 'self'  dev.oidc.gov.bc.ca; style-src 'unsafe-inline' 'self' https://fonts.googleapis.com https://fonts.gstatic.com ; font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubdomains; preload" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "no-referrer-when-downgrade";
+    gzip on;
+    gzip_min_length 1000;
+    gzip_proxied expired no-cache no-store private auth;
+    gzip_types text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+
+    location / {
+        try_files $uri $uri/ /index.html$args;
+    }
+    location /api/docman/ {
+        proxy_pass http://document-manager$SUFFIX-backend:6001;
+    }
+    location /api/v1/ {
+        proxy_pass http://dotnet-webapi$SUFFIX:8080/api/;
+    }
+}

--- a/prime-angular-frontend/nginx.template.conf
+++ b/prime-angular-frontend/nginx.template.conf
@@ -42,7 +42,7 @@ server {
 
 }
 server {
-    listen              8888 ssl;
+    listen              8888;
     server_name         *.gov.bc.ca;
     server_tokens off;
     root   /usr/share/nginx/html;

--- a/prime-angular-frontend/nginxdev.conf
+++ b/prime-angular-frontend/nginxdev.conf
@@ -54,3 +54,31 @@ server {
         proxy_pass http://dotnet-webapi$SUFFIX:8080/api/;
     }
 }
+server {
+    listen              8888;
+    server_name         *.gov.bc.ca;
+    server_tokens off;
+    root   /usr/share/nginx/html;
+    index  index.html index.htm;
+    include /etc/nginx/mime.types;
+    add_header X-Frame-Options "ALLOW-FROM dev.oidc.gov.bc.ca" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Content-Security-Policy "frame-ancestors 'self'  dev.oidc.gov.bc.ca; style-src 'unsafe-inline' 'self' https://fonts.googleapis.com https://fonts.gstatic.com ; font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubdomains; preload" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "no-referrer-when-downgrade";
+    gzip on;
+    gzip_min_length 1000;
+    gzip_proxied expired no-cache no-store private auth;
+    gzip_types text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+
+    location / {
+        try_files $uri $uri/ /index.html$args;
+    }
+    location /api/docman/ {
+        proxy_pass http://document-manager$SUFFIX-backend:6001;
+    }
+    location /api/v1/ {
+        proxy_pass http://dotnet-webapi$SUFFIX:8080/api/;
+    }
+}

--- a/prime-angular-frontend/nginxprod.conf
+++ b/prime-angular-frontend/nginxprod.conf
@@ -41,7 +41,7 @@ server {
     }
 }
 server {
-    listen              8888 ssl;
+    listen              8888;
     server_name         *.gov.bc.ca;
     server_tokens off;
     root   /usr/share/nginx/html;

--- a/prime-angular-frontend/nginxprod.conf
+++ b/prime-angular-frontend/nginxprod.conf
@@ -40,3 +40,31 @@ server {
         proxy_pass http://dotnet-webapi$SUFFIX:8080/api/;
     }
 }
+server {
+    listen              8888 ssl;
+    server_name         *.gov.bc.ca;
+    server_tokens off;
+    root   /usr/share/nginx/html;
+    index  index.html index.htm;
+    include /etc/nginx/mime.types;
+    add_header X-Frame-Options "ALLOW-FROM dev.oidc.gov.bc.ca" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Content-Security-Policy "frame-ancestors 'self'  dev.oidc.gov.bc.ca; style-src 'unsafe-inline' 'self' https://fonts.googleapis.com https://fonts.gstatic.com ; font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubdomains; preload" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "no-referrer-when-downgrade";
+    gzip on;
+    gzip_min_length 1000;
+    gzip_proxied expired no-cache no-store private auth;
+    gzip_types text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+
+    location / {
+        try_files $uri $uri/ /index.html$args;
+    }
+    location /api/docman/ {
+        proxy_pass http://document-manager$SUFFIX-backend:6001;
+    }
+    location /api/v1/ {
+        proxy_pass http://dotnet-webapi$SUFFIX:8080/api/;
+    }
+}

--- a/prime-angular-frontend/nginxtest.conf
+++ b/prime-angular-frontend/nginxtest.conf
@@ -54,3 +54,31 @@ server {
         proxy_pass http://dotnet-webapi$SUFFIX:8080/api/;
     }
 }
+server {
+    listen              8888;
+    server_name         *.gov.bc.ca;
+    server_tokens off;
+    root   /usr/share/nginx/html;
+    index  index.html index.htm;
+    include /etc/nginx/mime.types;
+    add_header X-Frame-Options "ALLOW-FROM dev.oidc.gov.bc.ca" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Content-Security-Policy "frame-ancestors 'self'  dev.oidc.gov.bc.ca; style-src 'unsafe-inline' 'self' https://fonts.googleapis.com https://fonts.gstatic.com ; font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubdomains; preload" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "no-referrer-when-downgrade";
+    gzip on;
+    gzip_min_length 1000;
+    gzip_proxied expired no-cache no-store private auth;
+    gzip_types text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+
+    location / {
+        try_files $uri $uri/ /index.html$args;
+    }
+    location /api/docman/ {
+        proxy_pass http://document-manager$SUFFIX-backend:6001;
+    }
+    location /api/v1/ {
+        proxy_pass http://dotnet-webapi$SUFFIX:8080/api/;
+    }
+}


### PR DESCRIPTION
Adding a PHSA eForms URL so that immunizers don't use the main PharmaNet Enrolment URL.