### PR TITLE
PRIME-1356 CLONE - College Licence Information and Practitioner ID

### DIFF
--- a/prime-angular-frontend/src/app/config/config.model.ts
+++ b/prime-angular-frontend/src/app/config/config.model.ts
@@ -37,6 +37,7 @@ export interface LicenseConfig extends Config<number> {
   licensedToProvideCare: boolean;
   namedInImReg: boolean;
   weight: number;
+  validate: boolean;
 }
 
 export interface CollegeLicenseConfig {

--- a/prime-angular-frontend/src/app/modules/enrolment/pages/regulatory/regulatory-form-state.ts
+++ b/prime-angular-frontend/src/app/modules/enrolment/pages/regulatory/regulatory-form-state.ts
@@ -2,6 +2,7 @@ import { FormArray, FormBuilder, FormGroup } from '@angular/forms';
 import { CollegeCertification } from '@enrolment/shared/models/college-certification.model';
 
 import { AbstractFormState } from '@lib/classes/abstract-form-state.class';
+import { FormControlValidators } from '@lib/validators/form-control.validators';
 
 export interface RegulatoryFormModel {
   certifications: CollegeCertification[];
@@ -64,10 +65,14 @@ export class RegulatoryFormState extends AbstractFormState<CollegeCertification[
     return this.fb.group({
       // Force selection of "None" on new certifications
       collegeCode: ['', []],
+      licenseCode: [null, []],
       // Validators are applied at the component-level when
       // fields are made visible to allow empty submissions
       licenseNumber: [null, []],
-      licenseCode: [null, []],
+      practitionerId: [null, [
+        FormControlValidators.requiredLength(5),
+        FormControlValidators.numeric
+      ]],
       renewalDate: [null, []],
       practiceCode: [null, []]
     });

--- a/prime-angular-frontend/src/app/modules/enrolment/shared/models/college-certification.model.ts
+++ b/prime-angular-frontend/src/app/modules/enrolment/shared/models/college-certification.model.ts
@@ -1,8 +1,9 @@
 export interface CollegeCertification {
   id?: number;
   collegeCode: number;
-  licenseNumber: string;
   licenseCode: number;
+  licenseNumber: string;
+  practitionerId: string;
   renewalDate: string;
   practiceCode?: number;
 }

--- a/prime-angular-frontend/src/app/shared/components/college-certification-form/college-certification-form.component.html
+++ b/prime-angular-frontend/src/app/shared/components/college-certification-form/college-certification-form.component.html
@@ -91,15 +91,15 @@
                       If you are a nurse practitioner, your Prescriber ID number was issued and communicated to you when
                       you were initially granted practising NP registration. Your Prescriber ID number is created with
                       the digits 96 and the last five digits of your College ID/Registration number. Please provide only
-                      the last 5 digits, without the leading “96”.
+                      the last 5 digits, without the leading "96".
                     </p>
                     <p *ngSwitchCase="CollegeLicenceClass.CPSBC">
-                      Your College ID number is called the “CPSID number” in your license letter. Provide only the last
-                      5 digits, without the leading zero.
+                      Your Practitioner ID number is called the "CPSID number" in your license letter. Provide only the
+                      last 5 digits, without the leading zero.
                     </p>
                     <div *ngSwitchCase="CollegeLicenceClass.CPBC">
                       <p>
-                        You may view your registration number on eServices by clicking “My Profile” and navigating to
+                        You may view your registration number on eServices by clicking "My Profile" and navigating to
                         either:
                       </p>
                       <ol>

--- a/prime-angular-frontend/src/app/shared/components/college-certification-form/college-certification-form.component.html
+++ b/prime-angular-frontend/src/app/shared/components/college-certification-form/college-certification-form.component.html
@@ -58,52 +58,15 @@
           <div class="row">
             <div class="col">
 
-              <app-form-icon-group>
-                <mat-form-field class="w-100">
-                  <input matInput
-                         placeholder="Licence Number"
-                         formControlName="licenseNumber">
-                  <mat-error *ngIf="form.get('licenseNumber').hasError('required')">Required</mat-error>
-                  <mat-error *ngIf="form.get('licenseNumber').hasError('alphanumeric')">
-                    Must contain only alphanumeric characters
-                  </mat-error>
-                </mat-form-field>
-
-                <ng-container appContextualContent>
-
-                  <ng-container [ngSwitch]="collegeCode.value">
-                    <p *ngSwitchCase="CollegeLicenceClass.BCCNM">
-                      If you are a nurse practitioner, your Prescriber ID number was issued and communicated to you when
-                      you were initially granted practising NP registration. Your Prescriber ID number is created with
-                      the digits 96 and the last five digits of your College ID/Registration number. Please provide only
-                      the last 5 digits, without the leading “96”.
-                    </p>
-                    <p *ngSwitchCase="CollegeLicenceClass.CPSBC">
-                      Your College ID number is called the “CPSID number” in your license letter. Provide only the last
-                      5 digits, without the leading zero.
-                    </p>
-                    <div *ngSwitchCase="CollegeLicenceClass.CPBC">
-                      <p>
-                        You may view your registration number on eServices by clicking “My Profile” and navigating to
-                        either:
-                      </p>
-                      <ol>
-                        <li>
-                          <strong>Update profile (view only)</strong> OR
-                        </li>
-                        <li>
-                          <strong>My Registration Card</strong> (downloads registration card containing your
-                          registration number)
-                        </li>
-                      </ol>
-                    </div>
-                    <p *ngSwitchDefault>
-                      Enter your College licence number
-                    </p>
-                  </ng-container>
-
-                </ng-container>
-              </app-form-icon-group>
+              <mat-form-field class="w-100">
+                <input matInput
+                       placeholder="Licence Number from College"
+                       formControlName="licenseNumber">
+                <mat-error *ngIf="form.get('licenseNumber').hasError('required')">Required</mat-error>
+                <mat-error *ngIf="form.get('licenseNumber').hasError('alphanumeric')">
+                  Must contain only alphanumeric characters
+                </mat-error>
+              </mat-form-field>
 
             </div>
           </div>

--- a/prime-angular-frontend/src/app/shared/components/college-certification-form/college-certification-form.component.html
+++ b/prime-angular-frontend/src/app/shared/components/college-certification-form/college-certification-form.component.html
@@ -37,6 +37,22 @@
       </div>
 
       <ng-container *ngIf="collegeCode.value">
+        <div *ngIf="filteredLicenses?.length > 1"
+             class="col-sm-12 pl-5">
+
+          <mat-form-field class="w-100">
+            <mat-label>Licence class issued by the college</mat-label>
+            <mat-select formControlName="licenseCode">
+              <mat-option *ngFor="let license of allowedLicenses()"
+                          [value]="license.code">
+                {{ license.name }}
+              </mat-option>
+            </mat-select>
+            <mat-error *ngIf="form.get('licenseCode').hasError('required')">Required</mat-error>
+          </mat-form-field>
+
+        </div>
+
         <div class="col-sm-12 pl-5">
 
           <div class="row">
@@ -91,22 +107,6 @@
 
             </div>
           </div>
-
-        </div>
-
-        <div *ngIf="filteredLicenses?.length > 1"
-             class="col-sm-12 pl-5">
-
-          <mat-form-field class="w-100">
-            <mat-label>Licence class issued by the college</mat-label>
-            <mat-select formControlName="licenseCode">
-              <mat-option *ngFor="let license of allowedLicenses()"
-                          [value]="license.code">
-                {{ license.name }}
-              </mat-option>
-            </mat-select>
-            <mat-error *ngIf="form.get('licenseCode').hasError('required')">Required</mat-error>
-          </mat-form-field>
 
         </div>
 

--- a/prime-angular-frontend/src/app/shared/components/college-certification-form/college-certification-form.component.html
+++ b/prime-angular-frontend/src/app/shared/components/college-certification-form/college-certification-form.component.html
@@ -61,12 +61,64 @@
               <mat-form-field class="w-100">
                 <input matInput
                        placeholder="Licence Number from College"
-                       formControlName="licenseNumber">
+                       formControlName="licenseNumber"
+                       (blur)="onLicenceNumberBlur()">
                 <mat-error *ngIf="form.get('licenseNumber').hasError('required')">Required</mat-error>
                 <mat-error *ngIf="form.get('licenseNumber').hasError('alphanumeric')">
                   Must contain only alphanumeric characters
                 </mat-error>
               </mat-form-field>
+
+            </div>
+            <div *ngIf="licenceValidatedByPharmaNet"
+                 class="col">
+
+              <app-form-icon-group>
+                <mat-form-field class="w-100">
+                  <input matInput
+                         placeholder="Practitioner ID"
+                         formControlName="practitionerId">
+                  <mat-error *ngIf="form.get('practitionerId').hasError('required')">Required</mat-error>
+                  <mat-error *ngIf="form.get('practitionerId').hasError('numeric')">
+                    Must contain only numeric characters
+                  </mat-error>
+                </mat-form-field>
+
+                <ng-container appContextualContent>
+
+                  <ng-container [ngSwitch]="collegeCode.value">
+                    <p *ngSwitchCase="CollegeLicenceClass.BCCNM">
+                      If you are a nurse practitioner, your Prescriber ID number was issued and communicated to you when
+                      you were initially granted practising NP registration. Your Prescriber ID number is created with
+                      the digits 96 and the last five digits of your College ID/Registration number. Please provide only
+                      the last 5 digits, without the leading “96”.
+                    </p>
+                    <p *ngSwitchCase="CollegeLicenceClass.CPSBC">
+                      Your College ID number is called the “CPSID number” in your license letter. Provide only the last
+                      5 digits, without the leading zero.
+                    </p>
+                    <div *ngSwitchCase="CollegeLicenceClass.CPBC">
+                      <p>
+                        You may view your registration number on eServices by clicking “My Profile” and navigating to
+                        either:
+                      </p>
+                      <ol>
+                        <li>
+                          <strong>Update profile (view only)</strong> OR
+                        </li>
+                        <li>
+                          <strong>My Registration Card</strong> (downloads registration card containing your
+                          registration number)
+                        </li>
+                      </ol>
+                    </div>
+                    <p *ngSwitchDefault>
+                      Enter your College licence number
+                    </p>
+                  </ng-container>
+
+                </ng-container>
+              </app-form-icon-group>
 
             </div>
           </div>

--- a/prime-angular-frontend/src/app/shared/components/college-certification-form/college-certification-form.component.ts
+++ b/prime-angular-frontend/src/app/shared/components/college-certification-form/college-certification-form.component.ts
@@ -138,9 +138,7 @@ export class CollegeCertificationFormComponent implements OnInit {
 
     this.licenseCode.valueChanges
       .subscribe((licenseCode: number) => {
-        this.licenceValidatedByPharmaNet = this.licenses
-          .filter(licenseConfig => licenseConfig.code === licenseCode)
-          .some(licenseConfig => licenseConfig.validate);
+        this.licenceValidatedByPharmaNet = this.checkLicenceCodeValidatedByPharmaNet(licenseCode);
 
         (this.licenceValidatedByPharmaNet)
           ? this.formUtilsService.setValidators(this.practitionerId, [
@@ -150,6 +148,8 @@ export class CollegeCertificationFormComponent implements OnInit {
           ])
           : this.formUtilsService.resetAndClearValidators(this.practitionerId);
       });
+
+    this.licenceValidatedByPharmaNet = this.checkLicenceCodeValidatedByPharmaNet(this.licenseCode.value);
   }
 
   private setCollegeCertification(collegeCode: number): void {
@@ -217,5 +217,11 @@ export class CollegeCertificationFormComponent implements OnInit {
 
   private filterPractices(collegeCode: number): PracticeConfig[] {
     return this.practices.filter(p => p.collegePractices.map(cl => cl.collegeCode).includes(collegeCode));
+  }
+
+  private checkLicenceCodeValidatedByPharmaNet(licenceCode: number): boolean {
+    return this.licenses
+      .filter(licenseConfig => licenseConfig.code === licenceCode)
+      .some(licenseConfig => licenseConfig.validate);
   }
 }

--- a/prime-angular-frontend/src/app/shared/components/college-certification-form/college-certification-form.component.ts
+++ b/prime-angular-frontend/src/app/shared/components/college-certification-form/college-certification-form.component.ts
@@ -173,8 +173,8 @@ export class CollegeCertificationFormComponent implements OnInit {
   }
 
   private setValidations() {
-    // this.formUtilsService.setValidators(this.licenseNumber, [Validators.required, FormControlValidators.alphanumeric]);
     this.formUtilsService.setValidators(this.licenseCode, [Validators.required]);
+    this.formUtilsService.setValidators(this.licenseNumber, [Validators.required, FormControlValidators.alphanumeric]);
 
     if (!this.condensed) {
       this.formUtilsService.setValidators(this.renewalDate, [Validators.required]);
@@ -182,8 +182,8 @@ export class CollegeCertificationFormComponent implements OnInit {
   }
 
   private resetCollegeCertification() {
-    this.licenseNumber.reset(null);
     this.licenseCode.reset(null);
+    this.licenseNumber.reset(null);
 
     if (!this.condensed) {
       this.renewalDate.reset(null);
@@ -192,8 +192,8 @@ export class CollegeCertificationFormComponent implements OnInit {
   }
 
   private removeValidations() {
-    this.formUtilsService.setValidators(this.licenseNumber, []);
     this.formUtilsService.setValidators(this.licenseCode, []);
+    this.formUtilsService.setValidators(this.licenseNumber, []);
 
     if (!this.condensed) {
       this.formUtilsService.setValidators(this.renewalDate, []);

--- a/prime-angular-frontend/src/app/shared/components/enrollee/enrollee-review/enrollee-review.component.html
+++ b/prime-angular-frontend/src/app/shared/components/enrollee/enrollee-review/enrollee-review.component.html
@@ -199,12 +199,16 @@
       {{ certification.collegeCode | configCode: 'colleges' | default }}
     </app-enrollee-property>
 
+    <app-enrollee-property title="Licence Class">
+      {{ certification.licenseCode | configCode: 'licenses' | default }}
+    </app-enrollee-property>
+
     <app-enrollee-property title="Licence Number">
       {{ certification.licenseNumber | default }}
     </app-enrollee-property>
 
-    <app-enrollee-property title="Licence Class">
-      {{ certification.licenseCode | configCode: 'licenses' | default }}
+    <app-enrollee-property title="Pratitioner ID">
+      {{ certification.practitionerId | default }}
     </app-enrollee-property>
 
     <app-enrollee-property title="Renewal Date">

--- a/prime-dotnet-webapi/Controllers/LookupsController.cs
+++ b/prime-dotnet-webapi/Controllers/LookupsController.cs
@@ -46,11 +46,11 @@ namespace Prime.Controllers
         /// </summary>
         [HttpPost("validate-licence", Name = nameof(LicenceCodeTest))]
         [Authorize(Policy = Policies.SuperAdmin)]
-        public async Task<ActionResult<PharmanetCollegeRecord>> LicenceCodeTest(string collegePrefix, string licenceNumber)
+        public async Task<ActionResult<PharmanetCollegeRecord>> LicenceCodeTest(string collegePrefix, string practitionerId)
         {
-            Certification cert = new Certification
+            var cert = new Certification
             {
-                LicenseNumber = licenceNumber,
+                PractitionerId = practitionerId,
                 License = new License
                 {
                     Prefix = collegePrefix

--- a/prime-dotnet-webapi/HttpClients/College Licence API/CollegeLicenceClient.cs
+++ b/prime-dotnet-webapi/HttpClients/College Licence API/CollegeLicenceClient.cs
@@ -87,7 +87,7 @@ namespace Prime.HttpClients
             {
                 ApplicationUUID = Guid.NewGuid().ToString();
                 ProgramArea = "PRIME";
-                LicenceNumber = cert.LicenseNumber ?? throw new ArgumentNullException(nameof(LicenceNumber));
+                LicenceNumber = cert.PractitionerId ?? throw new ArgumentNullException(nameof(LicenceNumber));
                 CollegeReferenceId = cert.License?.Prefix ?? throw new ArgumentNullException(nameof(CollegeReferenceId));
             }
         }

--- a/prime-dotnet-webapi/Migrations/20210126064650_AddedCertificationPractitionerId.Designer.cs
+++ b/prime-dotnet-webapi/Migrations/20210126064650_AddedCertificationPractitionerId.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Prime;
@@ -10,9 +11,10 @@ using Prime.Models;
 namespace Prime.Migrations
 {
     [DbContext(typeof(ApiDbContext))]
-    partial class ApiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210126064650_AddedCertificationPractitionerId")]
+    partial class AddedCertificationPractitionerId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/prime-dotnet-webapi/Migrations/20210126064650_AddedCertificationPractitionerId.cs
+++ b/prime-dotnet-webapi/Migrations/20210126064650_AddedCertificationPractitionerId.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Prime.Migrations
+{
+    public partial class AddedCertificationPractitionerId : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "PractitionerId",
+                table: "Certification",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PractitionerId",
+                table: "Certification");
+        }
+    }
+}

--- a/prime-dotnet-webapi/Models/Certifications/Certification.cs
+++ b/prime-dotnet-webapi/Models/Certifications/Certification.cs
@@ -6,7 +6,6 @@ using Prime.Infrastructure;
 
 namespace Prime.Models
 {
-
     [Table("Certification")]
     public class Certification : BaseAuditable, IEnrolleeNavigationProperty
     {
@@ -31,6 +30,9 @@ namespace Prime.Models
         [JsonConverter(typeof(EmptyStringToNullJsonConverter))]
         public string LicenseNumber { get; set; }
 
+        /// <summary>
+        ///  5-digit numeric number that the PharmaNet College API expects
+        /// </summary>
         [RegularExpression(@"([0-9]{5})", ErrorMessage = "Practitioner ID should be 5 numeric characters")]
         public string PractitionerId { get; set; }
 

--- a/prime-dotnet-webapi/Models/Certifications/Certification.cs
+++ b/prime-dotnet-webapi/Models/Certifications/Certification.cs
@@ -24,12 +24,15 @@ namespace Prime.Models
         [JsonIgnore]
         public College College { get; set; }
 
+        public int LicenseCode { get; set; }
+
         [Required]
         [RegularExpression(@"([a-zA-Z0-9]+)", ErrorMessage = "License Number should be alpha numeric characters")]
         [JsonConverter(typeof(EmptyStringToNullJsonConverter))]
         public string LicenseNumber { get; set; }
 
-        public int LicenseCode { get; set; }
+        [RegularExpression(@"([0-9]{5})", ErrorMessage = "Practitioner ID should be 5 numeric characters")]
+        public string PractitionerId { get; set; }
 
         [JsonIgnore]
         public License License { get; set; }

--- a/prime-dotnet-webapi/Models/Certifications/License.cs
+++ b/prime-dotnet-webapi/Models/Certifications/License.cs
@@ -18,7 +18,6 @@ namespace Prime.Models
         [JsonIgnore]
         public bool Manual { get; set; }
 
-        [JsonIgnore]
         public bool Validate { get; set; }
 
         public bool NamedInImReg { get; set; }


### PR DESCRIPTION
Testing using Postman:
1. Login as an Admin and get the access_token and add this to Auth Bearer Token
2. POST to the Lookups endpoint /validate-licence with collegePrefix 91 and practitionerId 20111 as query params
`https://pr-1081.pharmanetenrolment.gov.bc.ca/api/v1/Lookups/validate-licence?collegePrefix=91&practitionerId=20111`

![image](https://user-images.githubusercontent.com/599498/105933887-054cff80-6004-11eb-81ff-ebabc3582d73.png)