### PR TITLE
Remote access fields not being patched

### DIFF
--- a/prime-angular-frontend/src/app/modules/enrolment/shared/services/enrolment-form-state.service.ts
+++ b/prime-angular-frontend/src/app/modules/enrolment/shared/services/enrolment-form-state.service.ts
@@ -302,6 +302,11 @@ export class EnrolmentFormStateService extends AbstractFormStateService<Enrolmen
       remoteAccessSites.clear();
       enrolment.remoteAccessSites.forEach((ras: RemoteAccessSite) => {
         const remoteAccessSite = this.remoteAccessSiteFormGroup();
+        // Add the vendors, and then patch the remaining fields
+        const siteVendors = remoteAccessSite.get('siteVendors') as FormArray;
+        ras.site.siteVendors
+          .forEach(v => siteVendors.push(this.fb.group({ vendorCode: v.vendorCode })));
+
         remoteAccessSite.patchValue({
           enrolleeId: ras.enrolleeId,
           siteId: ras.siteId,
@@ -504,8 +509,11 @@ export class EnrolmentFormStateService extends AbstractFormStateService<Enrolmen
       enrolleeId: [null, []],
       siteId: [null, []],
       doingBusinessAs: [null, []],
-      physicalAddress: [null, []],
-      siteVendors: [null, []]
+      physicalAddress: this.formUtilsService.buildAddressForm({
+        areRequired: ['street', 'city', 'provinceCode', 'countryCode', 'postal'],
+        exclude: ['street2']
+      }),
+      siteVendors: this.fb.array([])
     });
   }
 


### PR DESCRIPTION
Remote access fields (physicalAddress and siteVendors) were not being patched outside of the remote access page since they weren't in the form state and were showing up as dashes in overview since the fields were always null.