### PR TITLE
Updated caddy download url in schemaspy

### DIFF
--- a/schemaspy/Dockerfile
+++ b/schemaspy/Dockerfile
@@ -14,7 +14,7 @@ RUN apk update && \
         tar \
         curl
 
-RUN curl -L "https://github.com/mholt/caddy/releases/download/v0.10.10/caddy_v0.10.10_linux_amd64.tar.gz" \
+RUN curl -L "https://github.com/caddyserver/caddy/releases/download/v0.10.10/caddy_v0.10.10_linux_amd64.tar.gz" \
     | tar --no-same-owner -C /usr/bin/ -xz caddy
 
 RUN apk del devs


### PR DESCRIPTION
- old URL no longer exists