### PR TITLE
Remove Deferred Reason on Care Setting Change

### DIFF
--- a/prime-angular-frontend/src/app/core/resources/site-resource.service.ts
+++ b/prime-angular-frontend/src/app/core/resources/site-resource.service.ts
@@ -258,7 +258,7 @@ export class SiteResource {
       );
   }
 
-  public removeBusinessLicenceDocument(siteId: number): Observable<ApiHttpResponse<NoContent>> {
+  public removeBusinessLicenceDocument(siteId: number): NoContent {
     return this.apiResource.delete<BusinessLicenceDocument>(`sites/${ siteId }/business-licence/document`)
       .pipe(
         NoContentResponse,

--- a/prime-angular-frontend/src/app/core/resources/site-resource.service.ts
+++ b/prime-angular-frontend/src/app/core/resources/site-resource.service.ts
@@ -113,12 +113,23 @@ export class SiteResource {
       );
   }
 
-  public updateCompleted(siteId: number): NoContent {
+  public setCompleted(siteId: number): NoContent {
     return this.apiResource.put<NoContent>(`sites/${ siteId }/completed`)
       .pipe(
         NoContentResponse,
         catchError((error: any) => {
-          this.logger.error('[SiteRegistration] SiteResource::updateSiteCompleted error has occurred: ', error);
+          this.logger.error('[SiteRegistration] SiteResource::setCompleted error has occurred: ', error);
+          throw error;
+        })
+      );
+  }
+
+  public removeCompleted(siteId: number): NoContent {
+    return this.apiResource.delete<NoContent>(`sites/${ siteId }/completed`)
+      .pipe(
+        NoContentResponse,
+        catchError((error: any) => {
+          this.logger.error('[SiteRegistration] SiteResource::removeCompleted error has occurred: ', error);
           throw error;
         })
       );

--- a/prime-angular-frontend/src/app/lib/classes/abstract-enrolment-page.class.ts
+++ b/prime-angular-frontend/src/app/lib/classes/abstract-enrolment-page.class.ts
@@ -31,6 +31,32 @@ export interface IEnrolmentPage {
  * @description
  * Class is used to provide a set of submission hooks and
  * functionality to pages used in enrolments.
+ *
+ * For example, outside of the boilerplate add getters for
+ * quickly accessing AbstractControls in controllers to
+ * reduce methods required in each controller.
+ *
+ * WARNING: Always use UntilDestroy in the controller to
+ * unsubscribe from valueChanges on getters when the component
+ * is destroyed. Not doing this will result in memory leaks, as
+ * well as, create issues that are difficult to trace.
+ *
+ * @example
+ * @UntilDestroy()
+ * @Component({
+ *   selector: 'app-example-page',
+ *   templateUrl: './example-page.component.html',
+ *   styleUrls: ['./example-page.component.scss']
+ * })
+ * export class ExamplePageComponent {
+ *   public initForm(): void {
+ *     this.formState.controlName.valueChanges
+ *       .pipe(
+ *         untilDestroyed(this),
+ *         ...
+ *       ).subscribe();
+ *   }
+ * }
  */
 // TODO make AbstractFormState generic on AbstractEnrolmentPage
 // export abstract class AbstractEnrolmentPage<T extends AbstractFormState<unknown>> implements IEnrolmentPage {

--- a/prime-angular-frontend/src/app/lib/classes/abstract-enrolment-page.class.ts
+++ b/prime-angular-frontend/src/app/lib/classes/abstract-enrolment-page.class.ts
@@ -1,4 +1,4 @@
-import { AbstractControl, FormGroup } from '@angular/forms';
+import { FormGroup } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 
 import { Observable, Subscription } from 'rxjs';

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/administrator-page/administrator-page.component.html
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/administrator-page/administrator-page.component.html
@@ -3,7 +3,7 @@
   <app-site-progress-indicator [inProgress]="!isCompleted"></app-site-progress-indicator>
 
   <app-contact-profile-form [title]="title"
-                            [form]="form"
+                            [form]="formState.form"
                             (submit)="onSubmit()">
     <app-same-as selectFor="administratorPharmaNet"
                  (selected)="onSelect($event)"></app-same-as>

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/administrator-page/administrator-page.component.ts
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/administrator-page/administrator-page.component.ts
@@ -51,7 +51,7 @@ export class AdministratorPageComponent extends AbstractEnrolmentPage implements
     if (!contact.physicalAddress) {
       contact.physicalAddress = new Address();
     }
-    this.form.patchValue(contact);
+    this.formState.form.patchValue(contact);
   }
 
   public onBack() {
@@ -75,14 +75,13 @@ export class AdministratorPageComponent extends AbstractEnrolmentPage implements
 
   protected createFormInstance() {
     this.formState = this.siteFormStateService.administratorPharmaNetFormState;
-    this.form = this.formState.form;
   }
 
   protected patchForm(): void {
     this.site = this.siteService.site;
     this.isCompleted = this.site?.completed;
     this.siteFormStateService.setForm(this.site, true);
-    this.form.markAsPristine();
+    this.formState.form.markAsPristine();
   }
 
   protected performSubmission(): NoContent {
@@ -91,7 +90,7 @@ export class AdministratorPageComponent extends AbstractEnrolmentPage implements
   }
 
   protected afterSubmitIsSuccessful(): void {
-    this.form.markAsPristine();
+    this.formState.form.markAsPristine();
 
     const routePath = (this.isCompleted)
       ? SiteRoutes.SITE_REVIEW

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/business-licence-page/business-licence-page-form-state.class.ts
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/business-licence-page/business-licence-page-form-state.class.ts
@@ -16,15 +16,15 @@ export class BusinessLicencePageFormState extends AbstractFormState<BusinessLice
   }
 
   public get businessLicenceGuid(): FormControl {
-    return this.form.get('businessLicenceGuid') as FormControl;
+    return this.formInstance.get('businessLicenceGuid') as FormControl;
   }
 
   public get deferredLicenceReason(): FormControl {
-    return this.form.get('deferredLicenceReason') as FormControl;
+    return this.formInstance.get('deferredLicenceReason') as FormControl;
   }
 
   public get doingBusinessAs(): FormControl {
-    return this.form.get('doingBusinessAs') as FormControl;
+    return this.formInstance.get('doingBusinessAs') as FormControl;
   }
 
   /**

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/business-licence-page/business-licence-page.component.html
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/business-licence-page/business-licence-page.component.html
@@ -4,7 +4,8 @@
 
   <form (ngSubmit)="onSubmit()"
         [formGroup]="formState.form"
-        novalidate>
+        novalidate
+        autocomplete="off">
 
     <section class="mb-4">
       <app-page-subheader2>
@@ -19,8 +20,7 @@
                            labelMessage="Drag and drop your business licence or browse"
                            [multiple]="false"
                            (completed)="onUpload($event)"
-                           (remove)="onRemoveDocument($event)">
-      </app-document-upload>
+                           (remove)="onRemoveDocument($event)"></app-document-upload>
 
       <app-alert *ngIf="hasNoBusinessLicenceError"
                  type="danger"

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/business-licence-page/business-licence-page.component.html
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/business-licence-page/business-licence-page.component.html
@@ -43,45 +43,45 @@
         </app-enrollee-property>
 
       </ng-container>
-    </section>
 
-    <app-site-name [form]="formState.form"
-                   [organizationId]="site.organizationId"></app-site-name>
+      <ng-container *ngIf="isCommPharm()">
 
-    <ng-container *ngIf="isCommPharm()">
+        <mat-slide-toggle #deferredLicence
+                          class="my-2 mb-3"
+                          color="primary"
+                          (change)="onDeferredLicenceChange($event)">
+          This Community Pharmacy does not have a business licence
+        </mat-slide-toggle>
 
-      <mat-slide-toggle #deferredLicence
-                        class="mb-3"
-                        color="primary"
-                        (change)="onDeferredLicenceChange($event)">
-        This Community Pharmacy does not have a business licence
-      </mat-slide-toggle>
+        <section class="mb-3"
+                 *ngIf="deferredLicence?.checked">
+          <app-page-subheader2>
+            <ng-container appPageSubheader2Title>Missing Business Licence</ng-container>
+            <ng-container appPageSubheader2Summary>
+              If your business does not yet have a business license, or if you are located in a municipality or region
+              that does not issue business licenses, provide a description below detailing the reason your business does
+              not have a license. PRIME Support staff will contact you and assist you with determining the correct
+              documents to upload. You may continue with your enrolment for now.
+            </ng-container>
+          </app-page-subheader2>
 
-      <section class="mb-3"
-               *ngIf="deferredLicence?.checked">
-        <app-page-subheader2>
-          <ng-container appPageSubheader2Title>Missing Business Licence</ng-container>
-          <ng-container appPageSubheader2Summary>
-            If your business does not yet have a business license, or if you are located in a municipality or region
-            that does not issue business licenses, provide a description below detailing the reason your business does
-            not have a license. PRIME Support staff will contact you and assist you with determining the correct
-            documents to upload. You may continue with your enrolment for now.
-          </ng-container>
-        </app-page-subheader2>
-
-        <div class="row">
-          <div class="col">
-            <mat-form-field class="w-100">
+          <div class="row">
+            <div class="col">
+              <mat-form-field class="w-100">
               <textarea matInput
                         rows="5"
                         placeholder="Write here"
                         formControlName="deferredLicenceReason"></textarea>
-              <mat-error>Required</mat-error>
-            </mat-form-field>
+                <mat-error>Required</mat-error>
+              </mat-form-field>
+            </div>
           </div>
-        </div>
-      </section>
-    </ng-container>
+        </section>
+      </ng-container>
+    </section>
+
+    <app-site-name [form]="formState.form"
+                   [organizationId]="site.organizationId"></app-site-name>
 
   </form>
 

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/business-licence-page/business-licence-page.component.ts
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/business-licence-page/business-licence-page.component.ts
@@ -4,15 +4,13 @@ import { Validators } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSlideToggle, MatSlideToggleChange } from '@angular/material/slide-toggle';
 
-import { Observable } from 'rxjs';
-import { exhaustMap } from 'rxjs/operators';
+import { Observable, concat } from 'rxjs';
 
 import { AbstractEnrolmentPage } from '@lib/classes/abstract-enrolment-page.class';
 import { RouteUtils } from '@lib/utils/route-utils.class';
 import { SiteResource } from '@core/resources/site-resource.service';
 import { UtilsService } from '@core/services/utils.service';
 import { FormUtilsService } from '@core/services/form-utils.service';
-import { NoContent } from '@core/resources/abstract-resource';
 import { BaseDocument, DocumentUploadComponent } from '@shared/components/document-upload/document-upload/document-upload.component';
 import { CareSettingEnum } from '@shared/enums/care-setting.enum';
 
@@ -64,35 +62,33 @@ export class BusinessLicencePageComponent extends AbstractEnrolmentPage implemen
     this.businessLicence = new BusinessLicence(this.siteService.site.id);
   }
 
-  public isCommPharm() {
+  public isCommPharm(): boolean {
     return this.siteService.site.careSettingCode === CareSettingEnum.COMMUNITY_PHARMACIST;
   }
 
-  public onUpload(document: BaseDocument) {
-    this.formState.businessLicenceGuid.value.patchValue(document.documentGuid);
+  public onUpload(document: BaseDocument): void {
+    this.formState.businessLicenceGuid.patchValue(document.documentGuid);
     this.uploadedFile = true;
     this.hasNoBusinessLicenceError = false;
   }
 
-  public onRemoveDocument(documentGuid: string) {
-    this.formState.businessLicenceGuid.value.patchValue(null);
+  public onRemoveDocument(documentGuid: string): void {
+    this.formState.businessLicenceGuid.patchValue(null);
     this.uploadedFile = false;
   }
 
-  public onBack() {
+  public onBack(): void {
     this.routeUtils.routeRelativeTo(SiteRoutes.CARE_SETTING);
   }
 
-  public downloadBusinessLicence(event: Event) {
+  public downloadBusinessLicence(event: Event): void {
     event.preventDefault();
     this.siteResource.getBusinessLicenceDocumentToken(this.siteService.site.id)
-      .subscribe((token: string) =>
-        this.utilsService.downloadToken(token)
-      );
+      .subscribe((token: string) => this.utilsService.downloadToken(token));
   }
 
-  public onDeferredLicenceChange($event: MatSlideToggleChange) {
-    if ($event.checked) {
+  public onDeferredLicenceChange(event: MatSlideToggleChange): void {
+    if (event.checked) {
       this.formState.deferredLicenceReason.setValidators([Validators.required]);
       this.formUtilsService.resetAndClearValidators(this.formState.doingBusinessAs);
       this.hasNoBusinessLicenceError = false;
@@ -107,13 +103,13 @@ export class BusinessLicencePageComponent extends AbstractEnrolmentPage implemen
     this.formState.form.markAsUntouched();
   }
 
-  public ngOnInit() {
+  public ngOnInit(): void {
     this.createFormInstance();
     this.patchForm();
     this.initForm();
   }
 
-  protected createFormInstance() {
+  protected createFormInstance(): void {
     this.formState = this.siteFormStateService.businessLicencePageFormState;
   }
 
@@ -143,48 +139,46 @@ export class BusinessLicencePageComponent extends AbstractEnrolmentPage implemen
     }
   }
 
-  protected performSubmission(): Observable<BusinessLicence | BusinessLicenceDocument> | NoContent {
+  protected performSubmission(): Observable<BusinessLicence | BusinessLicenceDocument | void> {
+    // Collect a list of requests that will be executed in order, which
+    // will always update the site initially
+    const requests$: Observable<BusinessLicence | BusinessLicenceDocument | void>[] = [
+      this.siteResource.updateSite(this.siteFormStateService.json)
+    ];
     const siteId = this.route.snapshot.params.sid;
-    const payload = this.siteFormStateService.json;
-    let request$: Observable<BusinessLicence | BusinessLicenceDocument> | NoContent;
+    const hasBusinessLicence = !!this.businessLicence.id;
 
-    if (this.deferredLicenceToggle?.checked) {
+    // Create or update the business licence with an uploaded document, otherwise
+    // with a deferred licence reason
+    if (this.deferredLicenceToggle.checked) {
       this.businessLicence.deferredLicenceReason = this.formState.deferredLicenceReason.value;
 
-      if (this.businessLicence.id) {
-        // Update the business licence, and if a document already exists remove it
-        const updateBusinessLicence$ = this.siteResource.updateBusinessLicence(siteId, this.businessLicence);
-        request$ = (this.businessLicence.businessLicenceDocument)
-          ? this.siteResource.removeBusinessLicenceDocument(siteId).pipe(exhaustMap(() => updateBusinessLicence$))
-          : updateBusinessLicence$;
+      if (!hasBusinessLicence) {
+        requests$.push(this.siteResource.createBusinessLicence(siteId, this.businessLicence, null));
+      } else {
+        // Perform an update by removing an existing business licence document
+        // and/or update the deferred reason
+        if (this.businessLicence.businessLicenceDocument) {
+          requests$.push(this.siteResource.removeBusinessLicenceDocument(siteId));
+        }
+        requests$.push(this.siteResource.updateBusinessLicence(siteId, this.businessLicence));
       }
-      else {
-        // Initial time through, and no business licence exists
-        request$ = this.siteResource.createBusinessLicence(siteId, this.businessLicence, null);
-      }
-    }
-    else {
-      const updateSite$ = this.siteResource.updateSite(payload);
+    } else {
+      const businessLicenceGuid = this.formState.businessLicenceGuid.value;
 
-      if (this.businessLicence.id) {
-        // Update the site, and if a document has been uploaded create a new business licence
-        request$ = (this.uploadedFile)
-          ? updateSite$.pipe(exhaustMap(() => this.siteResource.createBusinessLicenceDocument(siteId, this.formState.businessLicenceGuid.value)))
-          : updateSite$;
-      }
-      else {
-        // Initial time through and no business licence exists
-        request$ = updateSite$.pipe(exhaustMap(() =>
-          this.siteResource.createBusinessLicence(siteId, this.businessLicence, this.formState.businessLicenceGuid.value)));
+      if (!hasBusinessLicence) {
+        requests$.push(this.siteResource.createBusinessLicence(siteId, this.businessLicence, businessLicenceGuid));
+      } else if (this.uploadedFile) {
+        requests$.push(this.siteResource.createBusinessLicenceDocument(siteId, businessLicenceGuid));
       }
     }
 
-    return request$;
+    return concat(...requests$);
   }
 
   protected afterSubmitIsSuccessful(): void {
     // Remove the business licence GUID to prevent 404 already
-    // submitted if resubmited in same session
+    // submitted if re-submitted in same session
     this.formState.businessLicenceGuid.patchValue(null);
     this.formState.form.markAsPristine();
 
@@ -195,12 +189,12 @@ export class BusinessLicencePageComponent extends AbstractEnrolmentPage implemen
     this.routeUtils.routeRelativeTo(routePath);
   }
 
-  private getBusinessLicence(site: Site) {
-    this.busy = this.siteResource.getBusinessLicence(site.id)
+  private getBusinessLicence(site: Site): void {
+    this.siteResource.getBusinessLicence(site.id)
       .subscribe((businessLicense: BusinessLicence) => {
         this.businessLicence = businessLicense ?? this.businessLicence;
         if (businessLicense && !businessLicense.completed) {
-          this.deferredLicenceToggle.checked = true;
+          this.deferredLicenceToggle.checked = !!this.businessLicence.deferredLicenceReason;
           this.formState.deferredLicenceReason.setValidators([Validators.required]);
           this.formUtilsService.resetAndClearValidators(this.formState.doingBusinessAs);
           this.hasNoBusinessLicenceError = false;

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/business-licence-page/business-licence-page.component.ts
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/business-licence-page/business-licence-page.component.ts
@@ -115,7 +115,6 @@ export class BusinessLicencePageComponent extends AbstractEnrolmentPage implemen
 
   protected createFormInstance() {
     this.formState = this.siteFormStateService.businessLicencePageFormState;
-    this.form = this.formState.form;
   }
 
   protected patchForm(): void {

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/care-setting-page/care-setting-page-form-state.class.ts
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/care-setting-page/care-setting-page-form-state.class.ts
@@ -1,4 +1,4 @@
-import { FormBuilder, Validators } from '@angular/forms';
+import { FormBuilder, FormControl, Validators } from '@angular/forms';
 
 import { AbstractFormState } from '@lib/classes/abstract-form-state.class';
 import { FormControlValidators } from '@lib/validators/form-control.validators';
@@ -15,6 +15,14 @@ export class CareSettingPageFormState extends AbstractFormState<CareSettingPageD
     super();
 
     this.buildForm();
+  }
+
+  public get careSettingCode(): FormControl {
+    return this.formInstance.get('careSettingCode') as FormControl;
+  }
+
+  public get vendorCode(): FormControl {
+    return this.formInstance.get('vendorCode') as FormControl;
   }
 
   public get json(): CareSettingPageDataModel {

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/care-setting-page/care-setting-page.component.html
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/care-setting-page/care-setting-page.component.html
@@ -3,8 +3,9 @@
   <app-site-progress-indicator [inProgress]="!isCompleted"></app-site-progress-indicator>
 
   <form (ngSubmit)="onSubmit()"
-        [formGroup]="form"
-        novalidate>
+        [formGroup]="formState.form"
+        novalidate
+        autocomplete="off">
 
     <section class="mb-3">
       <app-page-subheader2>
@@ -26,7 +27,7 @@
                 {{ careSetting.name }}
               </mat-option>
             </mat-select>
-            <mat-error *ngIf="careSettingCode.hasError('required')">
+            <mat-error *ngIf="formState.careSettingCode.hasError('required')">
               Required
             </mat-error>
           </mat-form-field>

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/care-setting-page/care-setting-page.component.ts
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/care-setting-page/care-setting-page.component.ts
@@ -1,11 +1,11 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { FormControl } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { MatRadioChange } from '@angular/material/radio';
 
-import { EMPTY } from 'rxjs';
-import { exhaustMap, map } from 'rxjs/operators';
+
+import { EMPTY, noop, of } from 'rxjs';
+import { exhaustMap, map, pairwise, tap } from 'rxjs/operators';
 
 import { Config, VendorConfig } from '@config/config.model';
 import { ConfigService } from '@config/config.service';
@@ -69,14 +69,6 @@ export class CareSettingPageComponent extends AbstractEnrolmentPage implements O
     this.filteredVendorConfig = [];
   }
 
-  public get careSettingCode(): FormControl {
-    return this.form.get('careSettingCode') as FormControl;
-  }
-
-  public get vendorCode(): FormControl {
-    return this.form.get('vendorCode') as FormControl;
-  }
-
   public onVendorChange(change: MatRadioChange) {
     this.hasNoVendorError = false;
 
@@ -113,28 +105,29 @@ export class CareSettingPageComponent extends AbstractEnrolmentPage implements O
 
   protected createFormInstance() {
     this.formState = this.siteFormStateService.careSettingPageFormState;
-    this.form = this.formState.form;
   }
 
   protected patchForm(): void {
     const site = this.siteService.site;
     this.isCompleted = site?.completed;
     this.siteFormStateService.setForm(site, true);
-    this.form.markAsPristine();
+    this.formState.form.markAsPristine();
   }
 
   protected initForm() {
-    this.careSettingCode.valueChanges
+    this.formState.careSettingCode.valueChanges
       .pipe(
         map((careSettingCode: number) =>
           this.vendorConfig.filter(
             (vendorConfig: VendorConfig) =>
               vendorConfig.careSettingCode === careSettingCode
           )
+        map((careSettingCode: CareSettingEnum) =>
+          this.vendorConfig.filter((vendorConfig: VendorConfig) => vendorConfig.careSettingCode === careSettingCode)
         )
       ).subscribe((vendors: VendorConfig[]) => {
         this.filteredVendorConfig = vendors;
-        this.vendorCode.patchValue(null);
+        this.formState.vendorCode.patchValue(null);
       });
 
     this.patchForm();
@@ -145,7 +138,7 @@ export class CareSettingPageComponent extends AbstractEnrolmentPage implements O
   }
 
   protected onSubmitFormIsInvalid(): void {
-    if (!this.vendorCode.value) {
+    if (!this.formState.vendorCode.value) {
       this.hasNoVendorError = true;
     }
   }
@@ -175,7 +168,7 @@ export class CareSettingPageComponent extends AbstractEnrolmentPage implements O
   }
 
   protected afterSubmitIsSuccessful(): void {
-    this.form.markAsPristine();
+    this.formState.form.markAsPristine();
 
     const routePath = (this.isCompleted)
       ? SiteRoutes.SITE_REVIEW

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/care-setting-page/care-setting-page.component.ts
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/care-setting-page/care-setting-page.component.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 import { MatRadioChange } from '@angular/material/radio';
 
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 
 import { EMPTY, noop, of } from 'rxjs';
 import { exhaustMap, map, pairwise, tap } from 'rxjs/operators';
@@ -26,6 +27,7 @@ import { SiteService } from '@registration/shared/services/site.service';
 import { SiteFormStateService } from '@registration/shared/services/site-form-state.service';
 import { CareSettingPageFormState } from './care-setting-page-form-state.class';
 
+@UntilDestroy()
 @Component({
   selector: 'app-care-setting-page',
   templateUrl: './care-setting-page.component.html',
@@ -117,6 +119,7 @@ export class CareSettingPageComponent extends AbstractEnrolmentPage implements O
   protected initForm() {
     this.formState.careSettingCode.valueChanges
       .pipe(
+        untilDestroyed(this),
         map((careSettingCode: CareSettingEnum) =>
           this.vendorConfig.filter((vendorConfig: VendorConfig) => vendorConfig.careSettingCode === careSettingCode)
         )

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/care-setting-page/care-setting-page.component.ts
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/care-setting-page/care-setting-page.component.ts
@@ -6,7 +6,7 @@ import { MatRadioChange } from '@angular/material/radio';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 
 import { EMPTY, noop, of } from 'rxjs';
-import { exhaustMap, map, pairwise, tap } from 'rxjs/operators';
+import {exhaustMap, map, pairwise, startWith, tap} from 'rxjs/operators';
 
 import { Config, VendorConfig } from '@config/config.model';
 import { ConfigService } from '@config/config.service';
@@ -120,6 +120,43 @@ export class CareSettingPageComponent extends AbstractEnrolmentPage implements O
     this.formState.careSettingCode.valueChanges
       .pipe(
         untilDestroyed(this),
+        startWith([null]),
+        pairwise(),
+        exhaustMap(([prevCareSettingCode, nextCareSettingCode]: [number, number]) => {
+          const deferredLicenceReason = this.siteFormStateService.businessLicencePageFormState.deferredLicenceReason;
+
+          // Reset the deferred licence reason when changing from Community Pharmacist as
+          // no other care setting allows for deferment of the business licence upload
+          if (
+            prevCareSettingCode !== CareSettingEnum.COMMUNITY_PHARMACIST ||
+            !deferredLicenceReason.value ||
+            // When a document has been uploaded the business licence can no longer be updated
+            this.siteService.site?.businessLicence?.completed
+          ) {
+            return of(nextCareSettingCode); // No reset required
+          }
+
+          const { id, businessLicence, completed } = this.siteService.site;
+          businessLicence.deferredLicenceReason = null;
+          return this.siteResource.updateBusinessLicence(id, businessLicence)
+            .pipe(
+              // When not reset prevents interaction with specific controls on business licence
+              tap(() => this.siteFormStateService.businessLicencePageFormState.deferredLicenceReason.reset()),
+              exhaustMap(() => {
+                // Do nothing if not completed, but when site is marked as completed reset it
+                // to force user through the wizard to ensure a business licence is uploaded
+                if (!completed) {
+                  return of(noop());
+                }
+
+                return this.siteResource.removeCompleted(id)
+                  // Will ensure that the user is routed to the next page, and not
+                  // overview if previously completed
+                  .pipe(tap(() => this.isCompleted = false));
+              }),
+              map(() => nextCareSettingCode)
+            );
+        }),
         map((careSettingCode: CareSettingEnum) =>
           this.vendorConfig.filter((vendorConfig: VendorConfig) => vendorConfig.careSettingCode === careSettingCode)
         )

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/care-setting-page/care-setting-page.component.ts
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/care-setting-page/care-setting-page.component.ts
@@ -117,15 +117,11 @@ export class CareSettingPageComponent extends AbstractEnrolmentPage implements O
   protected initForm() {
     this.formState.careSettingCode.valueChanges
       .pipe(
-        map((careSettingCode: number) =>
-          this.vendorConfig.filter(
-            (vendorConfig: VendorConfig) =>
-              vendorConfig.careSettingCode === careSettingCode
-          )
         map((careSettingCode: CareSettingEnum) =>
           this.vendorConfig.filter((vendorConfig: VendorConfig) => vendorConfig.careSettingCode === careSettingCode)
         )
-      ).subscribe((vendors: VendorConfig[]) => {
+      )
+      .subscribe((vendors: VendorConfig[]) => {
         this.filteredVendorConfig = vendors;
         this.formState.vendorCode.patchValue(null);
       });

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/hours-operation-page/hours-operation-page-form-state.class.ts
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/hours-operation-page/hours-operation-page-form-state.class.ts
@@ -1,4 +1,4 @@
-import { FormBuilder } from '@angular/forms';
+import { FormArray, FormBuilder } from '@angular/forms';
 
 import { AbstractFormState } from '@lib/classes/abstract-form-state.class';
 import { FormGroupValidators } from '@lib/validators/form-group.validators';
@@ -18,6 +18,10 @@ export class HoursOperationPageFormState extends AbstractFormState<BusinessDay[]
     super();
 
     this.buildForm();
+  }
+
+  public get businessDays(): FormArray {
+    return this.formInstance.get('businessDays') as FormArray;
   }
 
   public get json(): BusinessDay[] {

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/hours-operation-page/hours-operation-page.component.html
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/hours-operation-page/hours-operation-page.component.html
@@ -3,8 +3,9 @@
   <app-site-progress-indicator [inProgress]="!isCompleted"></app-site-progress-indicator>
 
   <form (ngSubmit)="onSubmit()"
-        [formGroup]="form"
-        novalidate>
+        [formGroup]="formState.form"
+        novalidate
+        autocomplete="off">
 
     <section class="mb-3">
 
@@ -25,7 +26,7 @@
       </app-alert>
 
       <ng-container formArrayName="businessDays"
-                    *ngFor="let businessDay of businessDays.controls; let i = index;">
+                    *ngFor="let businessDay of formState.businessDays.controls; let i = index;">
         <div class="row weekdays">
           <div class="col-sm-12 col-lg-auto day">
 

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/hours-operation-page/hours-operation-page.component.ts
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/hours-operation-page/hours-operation-page.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { FormGroup, FormArray, FormControl, Validators, FormGroupDirective } from '@angular/forms';
+import { FormGroup, FormControl, Validators, FormGroupDirective } from '@angular/forms';
 import { WeekDay } from '@angular/common';
 import { ShowOnDirtyErrorStateMatcher } from '@angular/material/core';
 import { MatDialog } from '@angular/material/dialog';
@@ -80,10 +80,6 @@ export class HoursOperationPageComponent extends AbstractEnrolmentPage implement
     this.routeUtils = new RouteUtils(route, router, SiteRoutes.SITES);
   }
 
-  public get businessDays(): FormArray {
-    return this.form.get('businessDays') as FormArray;
-  }
-
   public hasDay(group: FormGroup): boolean {
     return group.get('startTime').value !== null;
   }
@@ -130,7 +126,6 @@ export class HoursOperationPageComponent extends AbstractEnrolmentPage implement
 
   protected createFormInstance() {
     this.formState = this.siteFormStateService.hoursOperationPageFormState;
-    this.form = this.formState.form;
     this.busDayHoursErrStateMatcher = new BusinessDayHoursErrorStateMatcher();
   }
 
@@ -139,9 +134,9 @@ export class HoursOperationPageComponent extends AbstractEnrolmentPage implement
     this.isCompleted = site?.completed;
     // Force the site to be patched each time
     this.siteFormStateService.setForm(site, true);
-    this.form.markAsPristine();
+    this.formState.form.markAsPristine();
 
-    this.businessDays.controls.forEach((group: FormGroup) => {
+    this.formState.businessDays.controls.forEach((group: FormGroup) => {
       if (this.is24Hours(group)) {
         this.allowEditingHours(group, false);
       }
@@ -163,11 +158,11 @@ export class HoursOperationPageComponent extends AbstractEnrolmentPage implement
   protected performSubmission(): NoContent {
     const payload = this.siteFormStateService.json;
     return this.siteResource.updateSite(payload)
-      .pipe(tap(() => this.form.markAsPristine()));
+      .pipe(tap(() => this.formState.form.markAsPristine()));
   }
 
   protected afterSubmitIsSuccessful(): void {
-    this.form.markAsPristine();
+    this.formState.form.markAsPristine();
 
     const site = this.siteService.site;
     let routePath = SiteRoutes.REMOTE_USERS;

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/organization-agreement-page/organization-agreement-page-form-state.class.ts
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/organization-agreement-page/organization-agreement-page-form-state.class.ts
@@ -1,4 +1,4 @@
-import { FormBuilder } from '@angular/forms';
+import { FormBuilder, FormControl } from '@angular/forms';
 
 import { AbstractFormState } from '@lib/classes/abstract-form-state.class';
 
@@ -13,6 +13,10 @@ export class OrganizationAgreementPageFormState extends AbstractFormState<Organi
     super();
 
     this.buildForm();
+  }
+
+  public get organizationAgreementGuid(): FormControl {
+    return this.formInstance.get('organizationAgreementGuid') as FormControl;
   }
 
   public get json(): OrganizationAgreementPageDataModel {

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/organization-agreement-page/organization-agreement-page.component.ts
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/organization-agreement-page/organization-agreement-page.component.ts
@@ -149,7 +149,7 @@ export class OrganizationAgreementPageComponent extends AbstractEnrolmentPage im
             : this.organizationResource
               .acceptOrganizationAgreement(organizationId, this.agreementId)
         ),
-        exhaustMap(() => this.siteResource.updateCompleted((this.route.snapshot.params.sid)))
+        exhaustMap(() => this.siteResource.setCompleted((this.route.snapshot.params.sid)))
       );
   }
 

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/organization-agreement-page/organization-agreement-page.component.ts
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/organization-agreement-page/organization-agreement-page.component.ts
@@ -60,10 +60,6 @@ export class OrganizationAgreementPageComponent extends AbstractEnrolmentPage im
     this.routeUtils = new RouteUtils(route, router, SiteRoutes.MODULE_PATH);
   }
 
-  public get organizationAgreementGuid(): FormControl {
-    return this.form.get('organizationAgreementGuid') as FormControl;
-  }
-
   public onDownload() {
     this.organizationResource
       .getOrganizationAgreement(this.route.snapshot.params.oid, this.agreementId, true)
@@ -75,13 +71,13 @@ export class OrganizationAgreementPageComponent extends AbstractEnrolmentPage im
   }
 
   public onUpload(document: BaseDocument) {
-    this.organizationAgreementGuid.patchValue(document.documentGuid);
+    this.formState.organizationAgreementGuid.patchValue(document.documentGuid);
     this.hasUploadedFile = true;
     this.hasNoUploadError = false;
   }
 
   public onRemoveDocument(documentGuid: string) {
-    this.organizationAgreementGuid.patchValue(null);
+    this.formState.organizationAgreementGuid.patchValue(null);
   }
 
   public showDefaultAgreement() {
@@ -100,7 +96,6 @@ export class OrganizationAgreementPageComponent extends AbstractEnrolmentPage im
 
   protected createFormInstance() {
     this.formState = this.organizationFormStateService.organizationAgreementPageFormState;
-    this.form = this.formState.form;
   }
 
   protected patchForm(): void {
@@ -148,9 +143,9 @@ export class OrganizationAgreementPageComponent extends AbstractEnrolmentPage im
             : EMPTY
         ),
         exhaustMap(() =>
-          (this.organizationAgreementGuid.value)
+          (this.formState.organizationAgreementGuid.value)
             ? this.organizationResource
-              .acceptOrganizationAgreement(organizationId, this.agreementId, this.organizationAgreementGuid.value)
+              .acceptOrganizationAgreement(organizationId, this.agreementId, this.formState.organizationAgreementGuid.value)
             : this.organizationResource
               .acceptOrganizationAgreement(organizationId, this.agreementId)
         ),
@@ -161,8 +156,8 @@ export class OrganizationAgreementPageComponent extends AbstractEnrolmentPage im
   protected afterSubmitIsSuccessful(): void {
     // Remove the org agreement GUID to prevent 404 already
     // submitted if resubmited in the same session
-    this.organizationAgreementGuid.patchValue(null);
-    this.form.markAsPristine();
+    this.formState.organizationAgreementGuid.patchValue(null);
+    this.formState.form.markAsPristine();
 
     this.routeUtils.routeRelativeTo(SiteRoutes.SITE_REVIEW);
   }

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/organization-name-page/organization-name-page-form-state.class.ts
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/organization-name-page/organization-name-page-form-state.class.ts
@@ -1,4 +1,4 @@
-import { FormBuilder, Validators } from '@angular/forms';
+import { FormBuilder, FormControl, Validators } from '@angular/forms';
 
 import { AbstractFormState } from '@lib/classes/abstract-form-state.class';
 import { Organization } from '@registration/shared/models/organization.model';
@@ -12,6 +12,18 @@ export class OrganizationNamePageFormState extends AbstractFormState<Organizatio
     super();
 
     this.buildForm();
+  }
+
+  public get name(): FormControl {
+    return this.formInstance.get('name') as FormControl;
+  }
+
+  public get registrationId(): FormControl {
+    return this.formInstance.get('registrationId') as FormControl;
+  }
+
+  public get doingBusinessAs(): FormControl {
+    return this.formInstance.get('doingBusinessAs') as FormControl;
   }
 
   public get json(): OrganizationNamePageDataModel {

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/organization-name-page/organization-name-page.component.html
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/organization-name-page/organization-name-page.component.html
@@ -3,8 +3,9 @@
   <app-site-progress-indicator [inProgress]="!isCompleted"></app-site-progress-indicator>
 
   <form (ngSubmit)="onSubmit()"
-        [formGroup]="form"
-        novalidate>
+        [formGroup]="formState.form"
+        novalidate
+        autocomplete="off">
 
     <section class="mb-3">
       <app-page-subheader2>
@@ -62,7 +63,7 @@
                      color="primary"
                      target="_blank"
                      class="mt-3"
-                     [href]="getOrgBookLink(registrationId.value)">
+                     [href]="getOrgBookLink(formState.registrationId.value)">
                     View organization in OrgBook
                   </a>
                 </div>

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/organization-name-page/organization-name-page.component.ts
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/organization-name-page/organization-name-page.component.ts
@@ -54,18 +54,6 @@ export class OrganizationNamePageComponent extends AbstractEnrolmentPage impleme
     this.routeUtils = new RouteUtils(route, router, SiteRoutes.MODULE_PATH);
   }
 
-  public get name(): FormControl {
-    return this.form.get('name') as FormControl;
-  }
-
-  public get registrationId(): FormControl {
-    return this.form.get('registrationId') as FormControl;
-  }
-
-  public get doingBusinessAs(): FormControl {
-    return this.form.get('doingBusinessAs') as FormControl;
-  }
-
   public getOrgBookLink(orgId: string, display: boolean = false) {
     const url = 'https://www.orgbook.gov.bc.ca/en/organization';
     return (display)
@@ -79,7 +67,7 @@ export class OrganizationNamePageComponent extends AbstractEnrolmentPage impleme
       .pipe(
         this.orgBookResource.sourceIdMap(),
         tap((sourceId: string) => this.usedOrgBook = true),
-        tap((sourceId: string) => this.form.get('registrationId').patchValue(sourceId)),
+        tap((sourceId: string) => this.formState.form.get('registrationId').patchValue(sourceId)),
         this.getDoingBusinessAs()
       )
       .subscribe();
@@ -87,7 +75,7 @@ export class OrganizationNamePageComponent extends AbstractEnrolmentPage impleme
 
   public onInput() {
     this.usedOrgBook = false;
-    this.registrationId.reset();
+    this.formState.registrationId.reset();
   }
 
   public onBack() {
@@ -102,14 +90,13 @@ export class OrganizationNamePageComponent extends AbstractEnrolmentPage impleme
 
   protected createFormInstance() {
     this.formState = this.organizationFormStateService.organizationNamePageFormState;
-    this.form = this.formState.form;
   }
 
   protected patchForm(): void {
     const organization = this.organizationService.organization;
     this.isCompleted = organization?.completed;
     this.organizationFormStateService.setForm(organization, true);
-    this.form.markAsPristine();
+    this.formState.form.markAsPristine();
 
     this.usedOrgBook = !!organization?.registrationId;
 
@@ -121,7 +108,7 @@ export class OrganizationNamePageComponent extends AbstractEnrolmentPage impleme
   }
 
   protected initForm() {
-    this.name.valueChanges
+    this.formState.name.valueChanges
       .pipe(
         debounceTime(400),
         switchMap((value: string) => this.orgBookResource.autocomplete(value))
@@ -154,7 +141,7 @@ export class OrganizationNamePageComponent extends AbstractEnrolmentPage impleme
   }
 
   protected afterSubmitIsSuccessful(siteId?: number): void {
-    this.form.markAsPristine();
+    this.formState.form.markAsPristine();
 
     const redirectPath = this.route.snapshot.queryParams.redirect;
     let routePath: string | string[];

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/organization-name-page/organization-name-page.component.ts
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/organization-name-page/organization-name-page.component.ts
@@ -4,6 +4,8 @@ import { FormControl } from '@angular/forms';
 import { MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
 import { MatDialog } from '@angular/material/dialog';
 
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+
 import { Observable, of, pipe } from 'rxjs';
 import { debounceTime, switchMap, tap, exhaustMap, take, map } from 'rxjs/operators';
 
@@ -21,6 +23,7 @@ import { OrganizationFormStateService } from '@registration/shared/services/orga
 import { OrgBookResource } from '@registration/shared/services/org-book-resource.service';
 import { OrganizationNamePageFormState } from './organization-name-page-form-state.class';
 
+@UntilDestroy()
 @Component({
   selector: 'app-organization-name-page',
   templateUrl: './organization-name-page.component.html',
@@ -110,6 +113,7 @@ export class OrganizationNamePageComponent extends AbstractEnrolmentPage impleme
   protected initForm() {
     this.formState.name.valueChanges
       .pipe(
+        untilDestroyed(this),
         debounceTime(400),
         switchMap((value: string) => this.orgBookResource.autocomplete(value))
       )

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/organization-signing-authority-page/organization-signing-authority-page-form-state.class.ts
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/organization-signing-authority-page/organization-signing-authority-page-form-state.class.ts
@@ -1,4 +1,4 @@
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 
 import { AbstractFormState } from '@lib/classes/abstract-form-state.class';
 import { FormControlValidators } from '@lib/validators/form-control.validators';
@@ -14,6 +14,42 @@ export class OrganizationSigningAuthorityPageFormState extends AbstractFormState
     super();
 
     this.buildForm();
+  }
+
+  public get preferredFirstName(): FormControl {
+    return this.formInstance.get('preferredFirstName') as FormControl;
+  }
+
+  public get preferredLastName(): FormControl {
+    return this.formInstance.get('preferredLastName') as FormControl;
+  }
+
+  public get verifiedAddress(): FormGroup {
+    return this.formInstance.get('verifiedAddress') as FormGroup;
+  }
+
+  public get mailingAddress(): FormGroup {
+    return this.formInstance.get('mailingAddress') as FormGroup;
+  }
+
+  public get physicalAddress(): FormGroup {
+    return this.formInstance.get('physicalAddress') as FormGroup;
+  }
+
+  public get phone(): FormControl {
+    return this.formInstance.get('phone') as FormControl;
+  }
+
+  public get fax(): FormControl {
+    return this.formInstance.get('fax') as FormControl;
+  }
+
+  public get smsPhone(): FormControl {
+    return this.formInstance.get('smsPhone') as FormControl;
+  }
+
+  public get email(): FormControl {
+    return this.formInstance.get('email') as FormControl;
   }
 
   public get json(): Party {

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/organization-signing-authority-page/organization-signing-authority-page.component.html
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/organization-signing-authority-page/organization-signing-authority-page.component.html
@@ -3,8 +3,9 @@
   <app-site-progress-indicator [inProgress]="!isCompleted"></app-site-progress-indicator>
 
   <form (ngSubmit)="onSubmit()"
-        [formGroup]="form"
-        novalidate>
+        [formGroup]="formState.form"
+        novalidate
+        autocomplete="off">
 
     <section class="mb-3">
       <app-page-subheader2>
@@ -39,7 +40,7 @@
             </ng-container>
           </app-page-subheader2>
 
-          <app-preferred-name-form [form]="form"></app-preferred-name-form>
+          <app-preferred-name-form [form]="formState.form"></app-preferred-name-form>
         </section>
 
       </app-toggle-content>
@@ -71,7 +72,7 @@
               <ng-container appPageSubheader2Title>Physical Address</ng-container>
             </app-page-subheader2>
 
-            <app-address-form [form]="physicalAddress"
+            <app-address-form [form]="formState.physicalAddress"
                               [inBc]="true"
                               [showManualButton]="true"
                               [showAddressFields]="hasPhysicalAddress"></app-address-form>
@@ -89,7 +90,7 @@
           </ng-container>
         </app-page-subheader2>
 
-        <app-address-form [form]="physicalAddress"
+        <app-address-form [form]="formState.physicalAddress"
                           [inBc]="true"
                           [showManualButton]="true"
                           [showAddressFields]="hasPhysicalAddress"></app-address-form>
@@ -104,7 +105,7 @@
             <ng-container appPageSubheader2Title>Mailing Address</ng-container>
           </app-page-subheader2>
 
-          <app-address-form [form]="mailingAddress"
+          <app-address-form [form]="formState.mailingAddress"
                             [showManualButton]="true"
                             [showAddressFields]="hasMailingAddress"></app-address-form>
         </section>
@@ -140,8 +141,8 @@
                    formControlName="phone"
                    mask="(000) 000-0000"
                    [showMaskTyped]="false">
-            <mat-error *ngIf="phone.hasError('required')">Required</mat-error>
-            <mat-error *ngIf="phone.hasError('phone')">Must be a valid phone number</mat-error>
+            <mat-error *ngIf="formState.phone.hasError('required')">Required</mat-error>
+            <mat-error *ngIf="formState.phone.hasError('phone')">Must be a valid phone number</mat-error>
           </mat-form-field>
 
         </div>
@@ -151,8 +152,8 @@
             <input matInput
                    placeholder="Email"
                    formControlName="email">
-            <mat-error *ngIf="email.hasError('required')">Required</mat-error>
-            <mat-error *ngIf="email.hasError('email')">Must be a valid email address</mat-error>
+            <mat-error *ngIf="formState.email.hasError('required')">Required</mat-error>
+            <mat-error *ngIf="formState.email.hasError('email')">Must be a valid email address</mat-error>
           </mat-form-field>
 
         </div>
@@ -164,8 +165,8 @@
                    formControlName="smsPhone"
                    mask="(000) 000-0000"
                    [showMaskTyped]="false">
-            <mat-error *ngIf="smsPhone.hasError('required')">Required</mat-error>
-            <mat-error *ngIf="smsPhone.hasError('phone')">Must be a valid phone number</mat-error>
+            <mat-error *ngIf="formState.smsPhone.hasError('required')">Required</mat-error>
+            <mat-error *ngIf="formState.smsPhone.hasError('phone')">Must be a valid phone number</mat-error>
           </mat-form-field>
 
         </div>
@@ -177,8 +178,8 @@
                    formControlName="fax"
                    mask="(000) 000-0000"
                    [showMaskTyped]="false">
-            <mat-error *ngIf="fax.hasError('required')">Required</mat-error>
-            <mat-error *ngIf="fax.hasError('phone')">Must be a valid phone number</mat-error>
+            <mat-error *ngIf="formState.fax.hasError('required')">Required</mat-error>
+            <mat-error *ngIf="formState.fax.hasError('phone')">Must be a valid phone number</mat-error>
           </mat-form-field>
 
         </div>

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/organization-signing-authority-page/organization-signing-authority-page.component.ts
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/organization-signing-authority-page/organization-signing-authority-page.component.ts
@@ -56,60 +56,24 @@ export class OrganizationSigningAuthorityPageComponent extends AbstractEnrolment
   ) {
     super(dialog, formUtilsService);
 
-    this.title = this.route.snapshot.data.title;
+    this.title = route.snapshot.data.title;
     this.routeUtils = new RouteUtils(route, router, SiteRoutes.MODULE_PATH);
-  }
-
-  public get preferredFirstName(): FormControl {
-    return this.form.get('preferredFirstName') as FormControl;
-  }
-
-  public get preferredLastName(): FormControl {
-    return this.form.get('preferredLastName') as FormControl;
-  }
-
-  public get verifiedAddress(): FormGroup {
-    return this.form.get('verifiedAddress') as FormGroup;
-  }
-
-  public get mailingAddress(): FormGroup {
-    return this.form.get('mailingAddress') as FormGroup;
-  }
-
-  public get physicalAddress(): FormGroup {
-    return this.form.get('physicalAddress') as FormGroup;
-  }
-
-  public get phone(): FormControl {
-    return this.form.get('phone') as FormControl;
-  }
-
-  public get fax(): FormControl {
-    return this.form.get('fax') as FormControl;
-  }
-
-  public get smsPhone(): FormControl {
-    return this.form.get('smsPhone') as FormControl;
-  }
-
-  public get email(): FormControl {
-    return this.form.get('email') as FormControl;
   }
 
   public onPreferredNameChange({ checked }: MatSlideToggleChange): void {
     if (!this.hasPreferredName) {
-      this.form.get('preferredMiddleName').reset();
+      this.formState.form.get('preferredMiddleName').reset();
     }
 
-    this.togglePreferredNameValidators(checked, this.preferredFirstName, this.preferredLastName);
+    this.togglePreferredNameValidators(checked, this.formState.preferredFirstName, this.formState.preferredLastName);
   }
 
   public onPhysicalAddressChange({ checked }: MatSlideToggleChange): void {
-    this.toggleAddressLineValidators(checked, this.physicalAddress);
+    this.toggleAddressLineValidators(checked, this.formState.physicalAddress);
   }
 
   public onMailingAddressChange({ checked }: MatSlideToggleChange): void {
-    this.toggleAddressLineValidators(checked, this.mailingAddress, this.hasVerifiedAddress);
+    this.toggleAddressLineValidators(checked, this.formState.mailingAddress, this.hasVerifiedAddress);
   }
 
   public onBack(): void {
@@ -135,7 +99,7 @@ export class OrganizationSigningAuthorityPageComponent extends AbstractEnrolment
         map((bcscUser: BcscUser) => {
           const { firstName, lastName, givenNames } = bcscUser;
           const verifiedAddress = bcscUser.verifiedAddress ?? new Address();
-          this.form.patchValue({ firstName, lastName, givenNames, verifiedAddress });
+          this.formState.form.patchValue({ firstName, lastName, givenNames, verifiedAddress });
         })
       )
       .subscribe(() => this.initForm());
@@ -143,7 +107,6 @@ export class OrganizationSigningAuthorityPageComponent extends AbstractEnrolment
 
   protected createFormInstance(): void {
     this.formState = this.organizationFormStateService.organizationSigningAuthorityPageFormState;
-    this.form = this.formState.form;
   }
 
   protected patchForm(): void {
@@ -156,20 +119,20 @@ export class OrganizationSigningAuthorityPageComponent extends AbstractEnrolment
   }
 
   protected initForm(): void {
-    this.hasPreferredName = !!(this.preferredFirstName.value || this.preferredLastName.value);
-    this.togglePreferredNameValidators(this.hasPreferredName, this.preferredFirstName, this.preferredLastName);
+    this.hasPreferredName = !!(this.formState.preferredFirstName.value || this.formState.preferredLastName.value);
+    this.togglePreferredNameValidators(this.hasPreferredName, this.formState.preferredFirstName, this.formState.preferredLastName);
 
     this.hasVerifiedAddress = Address.isNotEmpty(this.bcscUser.verifiedAddress);
     if (!this.hasVerifiedAddress) {
-      this.clearAddressValidator(this.verifiedAddress);
-      this.setAddressValidator(this.physicalAddress);
+      this.clearAddressValidator(this.formState.verifiedAddress);
+      this.setAddressValidator(this.formState.physicalAddress);
     } else {
-      this.hasPhysicalAddress = Address.isNotEmpty(this.physicalAddress.value);
-      this.toggleAddressLineValidators(this.hasPhysicalAddress, this.physicalAddress);
+      this.hasPhysicalAddress = Address.isNotEmpty(this.formState.physicalAddress.value);
+      this.toggleAddressLineValidators(this.hasPhysicalAddress, this.formState.physicalAddress);
     }
 
-    this.hasMailingAddress = Address.isNotEmpty(this.mailingAddress.value);
-    this.toggleAddressLineValidators(this.hasMailingAddress, this.mailingAddress, this.hasVerifiedAddress);
+    this.hasMailingAddress = Address.isNotEmpty(this.formState.mailingAddress.value);
+    this.toggleAddressLineValidators(this.hasMailingAddress, this.formState.mailingAddress, this.hasVerifiedAddress);
   }
 
   protected performSubmission(): NoContent {
@@ -178,7 +141,7 @@ export class OrganizationSigningAuthorityPageComponent extends AbstractEnrolment
   }
 
   protected afterSubmitIsSuccessful(): void {
-    this.form.markAsPristine();
+    this.formState.form.markAsPristine();
 
     const redirectPath = this.route.snapshot.queryParams.redirect;
     let routePath: string | string[];

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/privacy-officer-page/privacy-officer-page.component.html
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/privacy-officer-page/privacy-officer-page.component.html
@@ -3,7 +3,7 @@
   <app-site-progress-indicator [inProgress]="!isCompleted"></app-site-progress-indicator>
 
   <app-contact-profile-form [title]="title"
-                            [form]="form"
+                            [form]="formState.form"
                             (submit)="onSubmit()">
     <app-same-as selectFor="privacyOfficer"
                  (selected)="onSelect($event)"></app-same-as>

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/privacy-officer-page/privacy-officer-page.component.ts
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/privacy-officer-page/privacy-officer-page.component.ts
@@ -49,7 +49,7 @@ export class PrivacyOfficerPageComponent extends AbstractEnrolmentPage implement
     if (!contact.physicalAddress) {
       contact.physicalAddress = new Address();
     }
-    this.form.patchValue(contact);
+    this.formState.form.patchValue(contact);
   }
 
   public onBack() {
@@ -63,14 +63,13 @@ export class PrivacyOfficerPageComponent extends AbstractEnrolmentPage implement
 
   protected createFormInstance() {
     this.formState = this.siteFormStateService.privacyOfficerFormState;
-    this.form = this.formState.form;
   }
 
   protected patchForm(): void {
     this.site = this.siteService.site;
     this.isCompleted = this.site?.completed;
     this.siteFormStateService.setForm(this.site, true);
-    this.form.markAsPristine();
+    this.formState.form.markAsPristine();
   }
 
   protected performSubmission(): NoContent {
@@ -79,7 +78,7 @@ export class PrivacyOfficerPageComponent extends AbstractEnrolmentPage implement
   }
 
   protected afterSubmitIsSuccessful(): void {
-    this.form.markAsPristine();
+    this.formState.form.markAsPristine();
 
     const routePath = (this.isCompleted)
       ? SiteRoutes.SITE_REVIEW

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/remote-user-page/remote-user-page.component.html
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/remote-user-page/remote-user-page.component.html
@@ -2,9 +2,10 @@
   <app-page-header>PharmaNet Site Registration</app-page-header>
   <app-site-progress-indicator [inProgress]="!isCompleted"></app-site-progress-indicator>
 
-  <form [formGroup]="form"
+  <form [formGroup]="formState.form"
         (ngOnSubmit)="onSubmit()"
-        novalidate>
+        novalidate
+        autocomplete="off">
 
     <app-page-subheader2>
       <ng-container appPageSubheader2Title>
@@ -57,18 +58,17 @@
         <div class="col col-sm-10 py-3"
              formArrayName="remoteUserCertifications">
 
-          <ng-container *ngFor="let certificate of remoteUserCertifications.controls; let i = index;"
+          <ng-container *ngFor="let certificate of formState.remoteUserCertifications.controls; let i = index;"
                         [formGroupName]="i">
 
             <app-college-certification-form [condensed]="true"
                                             [form]="certificate"
                                             [index]="i"
-                                            [total]="remoteUserCertifications.controls.length"
+                                            [total]="formState.remoteUserCertifications.controls.length"
                                             [selectedColleges]="selectedCollegeCodes"
                                             [collegeFilterPredicate]="collegeFilterPredicate()"
                                             [licenceFilterPredicate]="licenceFilterPredicate()"
-                                            (remove)="removeCertification($event)">
-            </app-college-certification-form>
+                                            (remove)="removeCertification($event)"></app-college-certification-form>
 
           </ng-container>
 

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/remote-users-page/remote-users-page-form-state.class.ts
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/remote-users-page/remote-users-page-form-state.class.ts
@@ -1,4 +1,4 @@
-import { FormArray, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { FormArray, FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 
 import { AbstractFormState } from '@lib/classes/abstract-form-state.class';
 import { FormArrayValidators } from '@lib/validators/form-array.validators';
@@ -13,6 +13,18 @@ export class RemoteUsersPageFormState extends AbstractFormState<RemoteUser[]> {
     super();
 
     this.buildForm();
+  }
+
+  public get remoteUsers(): FormArray {
+    return this.formInstance.get('remoteUsers') as FormArray;
+  }
+
+  public get hasRemoteUsers(): FormControl {
+    return this.formInstance.get('hasRemoteUsers') as FormControl;
+  }
+
+  public get remoteUserCertifications(): FormArray {
+    return this.formInstance.get('remoteUserCertifications') as FormArray;
   }
 
   public get json(): RemoteUser[] {

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/remote-users-page/remote-users-page.component.html
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/remote-users-page/remote-users-page.component.html
@@ -13,8 +13,9 @@
   </app-page-subheader2>
 
   <form (ngSubmit)="onSubmit()"
-        [formGroup]="form"
-        novalidate>
+        [formGroup]="formState.form"
+        novalidate
+        autocomplete="off">
 
     <mat-slide-toggle class="mb-3"
                       color="primary"
@@ -23,7 +24,7 @@
   </form>
 
   <section>
-    <ng-container *ngFor="let remoteUser of remoteUsers.controls; let i = index; let last = last">
+    <ng-container *ngFor="let remoteUser of formState.remoteUsers.controls; let i = index; let last = last">
 
       <app-summary-card icon="account_circle"
                         [title]="remoteUser.value | fullname"
@@ -67,7 +68,7 @@
   </app-alert>
 
   <button mat-button
-          *ngIf="hasRemoteUsers.value"
+          *ngIf="formState.hasRemoteUsers.value"
           type="button"
           color="primary"
           class="mb-3"

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/remote-users-page/remote-users-page.component.ts
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/remote-users-page/remote-users-page.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { FormGroup, FormArray, FormControl } from '@angular/forms';
+import { FormGroup, FormArray } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 
 import { noop, of } from 'rxjs';
@@ -52,14 +52,6 @@ export class RemoteUsersPageComponent extends AbstractEnrolmentPage implements O
     this.submitButtonText = 'Save and Continue';
   }
 
-  public get remoteUsers(): FormArray {
-    return this.form.get('remoteUsers') as FormArray;
-  }
-
-  public get hasRemoteUsers(): FormControl {
-    return this.form.get('hasRemoteUsers') as FormControl;
-  }
-
   public getRemoteUserProperties(remoteUser: FormGroup) {
     const remoteUserCertifications = remoteUser.controls?.remoteUserCertifications as FormArray;
 
@@ -78,7 +70,7 @@ export class RemoteUsersPageComponent extends AbstractEnrolmentPage implements O
   }
 
   public onRemove(index: number) {
-    this.remoteUsers.removeAt(index);
+    this.formState.remoteUsers.removeAt(index);
   }
 
   public onEdit(index: number) {
@@ -100,7 +92,6 @@ export class RemoteUsersPageComponent extends AbstractEnrolmentPage implements O
 
   protected createFormInstance() {
     this.formState = this.siteFormStateService.remoteUsersPageFormState;
-    this.form = this.formState.form;
   }
 
   protected patchForm(): void {
@@ -112,25 +103,25 @@ export class RemoteUsersPageComponent extends AbstractEnrolmentPage implements O
     // Remove query param from URL without refreshing
     this.router.navigate([], { queryParams: { fromRemoteUser: null } });
     this.siteFormStateService.setForm(site, !fromRemoteUser);
-    this.form.markAsPristine();
+    this.formState.form.markAsPristine();
   }
 
   protected initForm() {
-    this.remoteUsers.valueChanges
+    this.formState.remoteUsers.valueChanges
       .subscribe((remoteUsers: RemoteUser[]) => {
         (remoteUsers.length)
-          ? this.hasRemoteUsers.disable({ emitEvent: false })
-          : this.hasRemoteUsers.enable({ emitEvent: false });
+          ? this.formState.hasRemoteUsers.disable({ emitEvent: false })
+          : this.formState.hasRemoteUsers.enable({ emitEvent: false });
       });
 
-    this.hasRemoteUsers.valueChanges
+    this.formState.hasRemoteUsers.valueChanges
       .subscribe((hasRemoteUsers: boolean) => {
         (hasRemoteUsers)
-          ? this.remoteUsers.setValidators(FormArrayValidators.atLeast(1))
-          : this.remoteUsers.clearValidators();
+          ? this.formState.remoteUsers.setValidators(FormArrayValidators.atLeast(1))
+          : this.formState.remoteUsers.clearValidators();
 
         this.hasNoRemoteUserError = false;
-        this.remoteUsers.updateValueAndValidity({ emitEvent: false });
+        this.formState.remoteUsers.updateValueAndValidity({ emitEvent: false });
       });
 
     this.patchForm();
@@ -175,7 +166,7 @@ export class RemoteUsersPageComponent extends AbstractEnrolmentPage implements O
   }
 
   protected afterSubmitIsSuccessful(): void {
-    this.form.markAsPristine();
+    this.formState.form.markAsPristine();
 
     const routePath = (this.isCompleted)
       ? SiteRoutes.SITE_REVIEW

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/remote-users-page/remote-users-page.component.ts
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/remote-users-page/remote-users-page.component.ts
@@ -3,6 +3,8 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { FormGroup, FormArray } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+
 import { noop, of } from 'rxjs';
 import { exhaustMap } from 'rxjs/operators';
 
@@ -19,6 +21,7 @@ import { SiteService } from '@registration/shared/services/site.service';
 import { RemoteUser } from '@registration/shared/models/remote-user.model';
 import { RemoteUsersPageFormState } from './remote-users-page-form-state.class';
 
+@UntilDestroy()
 @Component({
   selector: 'app-remote-users-page',
   templateUrl: './remote-users-page.component.html',
@@ -108,6 +111,7 @@ export class RemoteUsersPageComponent extends AbstractEnrolmentPage implements O
 
   protected initForm() {
     this.formState.remoteUsers.valueChanges
+      .pipe(untilDestroyed(this))
       .subscribe((remoteUsers: RemoteUser[]) => {
         (remoteUsers.length)
           ? this.formState.hasRemoteUsers.disable({ emitEvent: false })
@@ -115,6 +119,7 @@ export class RemoteUsersPageComponent extends AbstractEnrolmentPage implements O
       });
 
     this.formState.hasRemoteUsers.valueChanges
+      .pipe(untilDestroyed(this))
       .subscribe((hasRemoteUsers: boolean) => {
         (hasRemoteUsers)
           ? this.formState.remoteUsers.setValidators(FormArrayValidators.atLeast(1))

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/site-address-page/site-address-page-form-state.class.ts
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/site-address-page/site-address-page-form-state.class.ts
@@ -1,4 +1,4 @@
-import { FormBuilder } from '@angular/forms';
+import { FormBuilder, FormGroup } from '@angular/forms';
 
 import { AbstractFormState } from '@lib/classes/abstract-form-state.class';
 import { FormUtilsService } from '@core/services/form-utils.service';
@@ -12,6 +12,14 @@ export class SiteAddressPageFormState extends AbstractFormState<Address> {
     super();
 
     this.buildForm();
+  }
+
+  public get name(): FormGroup {
+    return this.formInstance.get('name') as FormGroup;
+  }
+
+  public get physicalAddress(): FormGroup {
+    return this.formInstance.get('physicalAddress') as FormGroup;
   }
 
   public get json(): Address {

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/site-address-page/site-address-page.component.html
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/site-address-page/site-address-page.component.html
@@ -3,8 +3,9 @@
   <app-site-progress-indicator [inProgress]="!isCompleted"></app-site-progress-indicator>
 
   <form (ngSubmit)="onSubmit()"
-        [formGroup]="form"
-        novalidate>
+        [formGroup]="formState.form"
+        novalidate
+        autocomplete="off">
 
     <section class="mb-3">
       <app-page-subheader2>
@@ -15,7 +16,7 @@
         </ng-container>
       </app-page-subheader2>
 
-      <app-address-form [form]="physicalAddress"
+      <app-address-form [form]="formState.physicalAddress"
                         [formControlNames]="formControlNames"
                         [inBc]="true"
                         [showManualButton]="true"

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/site-address-page/site-address-page.component.ts
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/site-address-page/site-address-page.component.ts
@@ -1,9 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { FormGroup } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 
-import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
 
 import { RouteUtils } from '@lib/utils/route-utils.class';
@@ -12,7 +10,6 @@ import { FormUtilsService } from '@core/services/form-utils.service';
 import { SiteResource } from '@core/resources/site-resource.service';
 import { NoContent } from '@core/resources/abstract-resource';
 import { AddressLine } from '@shared/models/address.model';
-import { ConfirmDialogComponent } from '@shared/components/dialogs/confirm-dialog/confirm-dialog.component';
 
 import { SiteRoutes } from '@registration/site-registration.routes';
 import { SiteService } from '@registration/shared/services/site.service';
@@ -55,14 +52,6 @@ export class SiteAddressPageComponent extends AbstractEnrolmentPage implements O
     ];
   }
 
-  public get name(): FormGroup {
-    return this.form.get('name') as FormGroup;
-  }
-
-  public get physicalAddress(): FormGroup {
-    return this.form.get('physicalAddress') as FormGroup;
-  }
-
   public onBack() {
     this.routeUtils.routeRelativeTo(SiteRoutes.BUSINESS_LICENCE);
   }
@@ -74,7 +63,6 @@ export class SiteAddressPageComponent extends AbstractEnrolmentPage implements O
 
   protected createFormInstance() {
     this.formState = this.siteFormStateService.siteAddressPageFormState;
-    this.form = this.formState.form;
   }
 
   protected patchForm(): void {
@@ -82,7 +70,7 @@ export class SiteAddressPageComponent extends AbstractEnrolmentPage implements O
     this.isCompleted = site?.completed;
     // Force the site to be patched each time
     this.siteFormStateService.setForm(site, true);
-    this.form.markAsPristine();
+    this.formState.form.markAsPristine();
   }
 
   protected initForm() {
@@ -96,11 +84,11 @@ export class SiteAddressPageComponent extends AbstractEnrolmentPage implements O
   protected performSubmission(): NoContent {
     const payload = this.siteFormStateService.json;
     return this.siteResource.updateSite(payload)
-      .pipe(tap(() => this.form.markAsPristine()));
+      .pipe(tap(() => this.formState.form.markAsPristine()));
   }
 
   protected afterSubmitIsSuccessful(): void {
-    this.form.markAsPristine();
+    this.formState.form.markAsPristine();
 
     const routePath = (this.isCompleted)
       ? SiteRoutes.SITE_REVIEW

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/technical-support-page/technical-support-page.component.html
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/technical-support-page/technical-support-page.component.html
@@ -3,7 +3,7 @@
   <app-site-progress-indicator [inProgress]="!isCompleted"></app-site-progress-indicator>
 
   <app-contact-profile-form [title]="title"
-                            [form]="form"
+                            [form]="formState.form"
                             (submit)="onSubmit()">
     <app-same-as selectFor="technicalSupport"
                  (selected)="onSelect($event)"></app-same-as>

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/technical-support-page/technical-support-page.component.ts
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/technical-support-page/technical-support-page.component.ts
@@ -54,7 +54,7 @@ export class TechnicalSupportPageComponent extends AbstractEnrolmentPage impleme
     if (!contact.physicalAddress) {
       contact.physicalAddress = new Address();
     }
-    this.form.patchValue(contact);
+    this.formState.form.patchValue(contact);
   }
 
   public onBack() {
@@ -68,14 +68,13 @@ export class TechnicalSupportPageComponent extends AbstractEnrolmentPage impleme
 
   protected createFormInstance() {
     this.formState = this.siteFormStateService.technicalSupportFormState;
-    this.form = this.formState.form;
   }
 
   protected patchForm(): void {
     this.site = this.siteService.site;
     this.isCompleted = this.site?.completed;
     this.siteFormStateService.setForm(this.site, true);
-    this.form.markAsPristine();
+    this.formState.form.markAsPristine();
   }
 
   protected performSubmission(): Observable<boolean> {
@@ -103,7 +102,7 @@ export class TechnicalSupportPageComponent extends AbstractEnrolmentPage impleme
   }
 
   protected afterSubmitIsSuccessful(needsOrgAgreement?: boolean): void {
-    this.form.markAsPristine();
+    this.formState.form.markAsPristine();
 
     const routePath = (needsOrgAgreement)
       ? SiteRoutes.ORGANIZATION_AGREEMENT

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/technical-support-page/technical-support-page.component.ts
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/technical-support-page/technical-support-page.component.ts
@@ -94,7 +94,7 @@ export class TechnicalSupportPageComponent extends AbstractEnrolmentPage impleme
           // Mark the site as completed if an organization
           // agreement does not need to be signed
           (!needsOrgAgreement)
-            ? this.siteResource.updateCompleted(site.id)
+            ? this.siteResource.setCompleted(site.id)
               .pipe(map(() => needsOrgAgreement))
             : of(needsOrgAgreement)
         )

--- a/prime-angular-frontend/src/app/modules/site-registration/shared/components/contact-profile-form/contact-profile-form.component.html
+++ b/prime-angular-frontend/src/app/modules/site-registration/shared/components/contact-profile-form/contact-profile-form.component.html
@@ -1,5 +1,6 @@
 <form [formGroup]="form"
-      novalidate>
+      novalidate
+      autocomplete="off">
 
   <section class="mb-3">
     <app-page-subheader2>

--- a/prime-angular-frontend/src/app/modules/site-registration/shared/models/site.model.ts
+++ b/prime-angular-frontend/src/app/modules/site-registration/shared/models/site.model.ts
@@ -31,9 +31,11 @@ export interface Site {
   technicalSupportId?: number;
   technicalSupport: Contact;
   // States -----
+  // Indicates that a user has progressed through the entire enrolment, and
+  // reached the overview page switching them from wizard to spoking navigation
   completed: boolean;
-  approvedDate: string;
   submittedDate: string;
+  approvedDate: string;
   // Admin -----
   adjudicatorId: number;
   adjudicator: Admin;

--- a/prime-dotnet-webapi/Controllers/SitesController.cs
+++ b/prime-dotnet-webapi/Controllers/SitesController.cs
@@ -159,15 +159,15 @@ namespace Prime.Controllers
 
         // PUT: api/Sites/5/completed
         /// <summary>
-        /// Updates a sites state
+        /// Set a sites completed state.
         /// </summary>
         /// <param name="siteId"></param>
-        [HttpPut("{siteId}/completed", Name = nameof(UpdateSiteCompleted))]
+        [HttpPut("{siteId}/completed", Name = nameof(SetSiteCompleted))]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(typeof(ApiMessageResponse), StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
-        public async Task<IActionResult> UpdateSiteCompleted(int siteId)
+        public async Task<ActionResult> SetSiteCompleted(int siteId)
         {
             var site = await _siteService.GetSiteNoTrackingAsync(siteId);
             if (site == null)
@@ -180,7 +180,35 @@ namespace Prime.Controllers
                 return Forbid();
             }
 
-            await _siteService.UpdateCompletedAsync(siteId);
+            await _siteService.UpdateCompletedAsync(siteId, true);
+
+            return NoContent();
+        }
+
+        // DELETE: api/Sites/5/completed
+        /// <summary>
+        /// Remove a sites completed state.
+        /// </summary>
+        /// <param name="siteId"></param>
+        [HttpPut("{siteId}/completed", Name = nameof(RemoveSiteCompleted))]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ApiMessageResponse), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        public async Task<ActionResult> RemoveSiteCompleted(int siteId)
+        {
+            var site = await _siteService.GetSiteNoTrackingAsync(siteId);
+            if (site == null)
+            {
+                return NotFound(ApiResponse.Message($"Site not found with id {siteId}"));
+            }
+
+            if (!site.Provisioner.PermissionsRecord().AccessableBy(User))
+            {
+                return Forbid();
+            }
+
+            await _siteService.UpdateCompletedAsync(siteId, false);
 
             return NoContent();
         }

--- a/prime-dotnet-webapi/Services/SiteService.cs
+++ b/prime-dotnet-webapi/Services/SiteService.cs
@@ -254,12 +254,12 @@ namespace Prime.Services
             }
         }
 
-        public async Task<int> UpdateCompletedAsync(int siteId)
+        public async Task<int> UpdateCompletedAsync(int siteId, bool completed)
         {
             var site = await GetBaseSiteQuery()
                 .SingleOrDefaultAsync(s => s.Id == siteId);
 
-            site.Completed = true;
+            site.Completed = completed;
 
             _context.Update(site);
 

--- a/prime-dotnet-webapi/Services/interfaces/ISiteService.cs
+++ b/prime-dotnet-webapi/Services/interfaces/ISiteService.cs
@@ -12,7 +12,7 @@ namespace Prime.Services
         Task<Site> GetSiteAsync(int siteId);
         Task<int> CreateSiteAsync(int organizationId);
         Task<int> UpdateSiteAsync(int siteId, SiteUpdateModel updatedSite);
-        Task<int> UpdateCompletedAsync(int siteId);
+        Task<int> UpdateCompletedAsync(int siteId, bool completed);
         Task<Site> UpdateSiteAdjudicator(int siteId, int? adminId = null);
         Task<Site> UpdatePecCode(int siteId, string pecCode);
         Task DeleteSiteAsync(int siteId);


### PR DESCRIPTION
* Deferred reason blocks updates to the Site Name if the care setting was updated before submission of the site from Comm Pharm to Comm Prac

Testing Case 1:
1. Create a site as Comm Pharm with any vendor
2. Don't make any changes to Business Licence
3. Route back to Care Setting and change to Comm Prac with any vendor
4. Observe network and there should be no PUT to update business licence when no deferred reason exists

Testing Case 2:
1. Create a site as Comm Pharm with any vendor
2. Add a deferred reason on business licence upload
3. Route back to Care Setting and change to Comm Prac with any vendor
4. Observe network for PUT to remove deferred reason if it exists
5. Observe on next page GET for deferred reason of null

Test Case 3:
1. Create a site as Comm Pharm with any vendor
2. Add a deferred reason on business licence upload
3. Upload a business licence document as well
3. Route back to Care Setting and change to Comm Prac with any vendor
4. Observe network and there should be no PUT since business licences can't be updated after a document has been uploaded so the deferred reason will persist