### PR TITLE
Remove MOH Keycloak from default Policy

### DIFF
--- a/prime-dotnet-webapi/Auth/AuthenticationSetup.cs
+++ b/prime-dotnet-webapi/Auth/AuthenticationSetup.cs
@@ -1,4 +1,4 @@
-﻿using System.IdentityModel.Tokens.Jwt;
+using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
@@ -41,7 +41,7 @@ namespace Prime.Auth
 
             services.AddAuthorization(options =>
             {
-                options.DefaultPolicy = new AuthorizationPolicyBuilder(Schemes.PrimeJwt, Schemes.MohJwt)
+                options.DefaultPolicy = new AuthorizationPolicyBuilder(Schemes.PrimeJwt)
                     .RequireAuthenticatedUser()
                     .Build();
             });


### PR DESCRIPTION
The MOH Keycloak integration was preventing login due to it unexpectedly still running even after the PRIME Keycloak had already validated the token. This was compounded by the fact that the MOH Keycloak is behind a firewall, so would return 403 FORBIDDEN when the app tried to validate the token.

MOH Keycloak has been removed from the default policy. To use it, you can specify it in the Authorize attribute on a method/controller:

```C#
[Authorize(AuthenticationSchemes = Schemes.MohJwt)]
```

Note that, due to the PRIME scheme being part of the default policy, this example will _also_ run the PRIME JWT Scheme. If this becomes a problem, we may need to set up some explicit policies.