### PR TITLE
PRIME-1531 Prescriber ID Not Editable After Submission

### DIFF
--- a/prime-angular-frontend/src/app/modules/enrolment/pages/regulatory/regulatory.component.ts
+++ b/prime-angular-frontend/src/app/modules/enrolment/pages/regulatory/regulatory.component.ts
@@ -61,7 +61,7 @@ export class RegulatoryComponent extends BaseEnrolmentProfilePage implements OnI
   }
 
   public get certifications(): FormArray {
-    return this.formState.certifications;
+    return this.formState.certifications as FormArray;
   }
 
   public get selectedCollegeCodes(): number[] {

--- a/prime-angular-frontend/src/app/shared/components/forms/college-certification-form/college-certification-form.component.html
+++ b/prime-angular-frontend/src/app/shared/components/forms/college-certification-form/college-certification-form.component.html
@@ -154,7 +154,7 @@
               </mat-form-field>
 
               <ng-container appContextualContent>
-                <p>Your Prescriber ID is a 5-digit number assigned to you by the BCCNM, to allow you to prescribe.</p>
+                Your Prescriber ID is a 5-digit number assigned to you by the BCCNM, to allow you to prescribe.
               </ng-container>
             </app-form-icon-group>
 

--- a/prime-angular-frontend/src/app/shared/components/forms/college-certification-form/college-certification-form.component.ts
+++ b/prime-angular-frontend/src/app/shared/components/forms/college-certification-form/college-certification-form.component.ts
@@ -2,6 +2,8 @@ import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
 import { MatSlideToggleChange } from '@angular/material/slide-toggle';
 
+import { startWith } from 'rxjs/operators';
+
 import moment from 'moment';
 
 import { FormControlValidators } from '@lib/validators/form-control.validators';
@@ -146,8 +148,8 @@ export class CollegeCertificationFormComponent implements OnInit {
     if (this.condensed) {
       this.formUtilsService.setValidators(this.collegeCode, [Validators.required]);
     }
-    this.setCollegeCertification(this.collegeCode.value);
 
+    this.setCollegeCertification(this.collegeCode.value);
     this.collegeCode.valueChanges
       .subscribe((collegeCode: number) => {
         this.resetCollegeCertification();
@@ -155,31 +157,15 @@ export class CollegeCertificationFormComponent implements OnInit {
       });
 
     if (!this.condensed) {
+      const initialLicenceCode: number | null = +this.licenseCode?.value ?? null;
       this.licenseCode.valueChanges
+        // Allow for initialization of the licence code when
+        // the code already exists
+        .pipe(startWith(initialLicenceCode))
         .subscribe((licenseCode: number) => {
-          const prescriberIdType = this.prescriberIdTypeByLicenceCode(licenseCode);
-          let isPrescribing = this.isPrescribing;
-
-          switch (prescriberIdType) {
-            case PrescriberIdTypeEnum.NA:
-              // Ensures validators are cleared and value reset to prevent
-              // values persisting through to submission
-              this.resetPractitionerIdStateAndValidators();
-              break;
-            case PrescriberIdTypeEnum.Optional:
-              // Maintain validators only if the value exists
-              if (!this.practitionerId.value) {
-                this.resetPractitionerIdStateAndValidators();
-              }
-              // Ensures that changes in licence code from mandatory
-              // to optional will show the input
-              isPrescribing = this.practitionerId.value;
-              break;
-            case PrescriberIdTypeEnum.Mandatory:
-              break; // NOOP
+          if (licenseCode) {
+            this.setPractitionerInformation(licenseCode);
           }
-
-          this.setPractitionerIdStateAndValidators(prescriberIdType, isPrescribing);
         });
     } else {
       const prescriberIdType = this.prescriberIdTypeByLicenceCode(this.licenseCode.value);
@@ -215,8 +201,7 @@ export class CollegeCertificationFormComponent implements OnInit {
     const licenseNumberValidators = [Validators.required];
     if (this.collegeCode.value === CollegeLicenceClassEnum.CPSBC) {
       licenseNumberValidators.push(FormControlValidators.numeric, FormControlValidators.requiredLength(5));
-    }
-    else {
+    } else {
       licenseNumberValidators.push(FormControlValidators.alphanumeric);
     }
     this.formUtilsService.setValidators(this.licenseNumber, licenseNumberValidators);
@@ -235,6 +220,32 @@ export class CollegeCertificationFormComponent implements OnInit {
       this.practiceCode.reset(null);
       this.resetPractitionerIdStateAndValidators();
     }
+  }
+
+  private setPractitionerInformation(licenseCode: number) {
+    const prescriberIdType = this.prescriberIdTypeByLicenceCode(licenseCode);
+    let isPrescribing = this.isPrescribing;
+
+    switch (prescriberIdType) {
+      case PrescriberIdTypeEnum.NA:
+        // Ensures validators are cleared and value reset to prevent
+        // values persisting through to submission
+        this.resetPractitionerIdStateAndValidators();
+        break;
+      case PrescriberIdTypeEnum.Optional:
+        // Maintain validators only if the value exists
+        if (!this.practitionerId.value) {
+          this.resetPractitionerIdStateAndValidators();
+        }
+        // Ensures that changes in licence code from mandatory
+        // to optional will show the input
+        isPrescribing = this.practitionerId.value;
+        break;
+      case PrescriberIdTypeEnum.Mandatory:
+        break; // NOOP
+    }
+
+    this.setPractitionerIdStateAndValidators(prescriberIdType, isPrescribing);
   }
 
   private setPractitionerIdStateAndValidators(prescriberIdType: PrescriberIdTypeEnum, isPrescribing: boolean) {


### PR DESCRIPTION
Fixes issue where prescriber ID is not available when editing after submission of an enrolment.  Steps to reproduce provided, and should now result in seeing the prescriber ID for appropriate licence codes.

**Reproduction Steps**

* Create an enrolment for a Practicing Nurse Practitioner
* Add a licence number and prescriber ID to the college certification
* Submit the enrolment and accept the TOA
* Attempt to edit the college certificate by routing from the overview
* Prescriber ID won’t be editable