### PR TITLE
Fix Site registration selenium test

### DIFF
--- a/prime-e2e-tests/TestPrimeE2E.csproj
+++ b/prime-e2e-tests/TestPrimeE2E.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Bogus" Version="33.0.2" />
+    <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />


### PR DESCRIPTION
- more robust wait for page to load complete
- increased timeout
- must call driver.quit() on teardown to avoid memory leak
- improved and reliable logic on workflow check
- removed  calls to obsolete code (added reference to SeleniumExtras.WaitHelpers