### PR TITLE
PRIME-1512 - Cancel TOA Assignment

### DIFF
--- a/prime-angular-frontend/src/app/modules/adjudication/pages/enrollee-overview/enrollee-overview.component.html
+++ b/prime-angular-frontend/src/app/modules/adjudication/pages/enrollee-overview/enrollee-overview.component.html
@@ -52,6 +52,7 @@
                                (assignToa)="onAssignToa($event)"
                                (enableEnrollee)="onEnableEnrollee($event)"
                                (enableEditing)="onEnableEditing($event)"
+                               (cancelToa)="onCancelToa($event)"
                                (rerunRules)="onRerunRules($event)"
                                (toggleManualAdj)="onToggleManualAdj($event)">
       </app-adjudicator-actions>

--- a/prime-angular-frontend/src/app/modules/adjudication/shared/components/adjudication-container/adjudication-container.component.ts
+++ b/prime-angular-frontend/src/app/modules/adjudication/shared/components/adjudication-container/adjudication-container.component.ts
@@ -29,10 +29,10 @@ import { Role } from '@auth/shared/enum/role.enum';
 import { PermissionService } from '@auth/shared/services/permission.service';
 import { EnrolleeNote } from '@enrolment/shared/models/enrollee-note.model';
 
-import {AdjudicationResource} from '@adjudication/shared/services/adjudication-resource.service';
-import {AdjudicationRoutes} from '@adjudication/adjudication.routes';
-import {SendBulkEmailComponent} from '@shared/components/dialogs/content/send-bulk-email/send-bulk-email.component';
-import {BulkEmailType} from '@shared/enums/bulk-email-type';
+import { AdjudicationResource } from '@adjudication/shared/services/adjudication-resource.service';
+import { AdjudicationRoutes } from '@adjudication/adjudication.routes';
+import { SendBulkEmailComponent } from '@shared/components/dialogs/content/send-bulk-email/send-bulk-email.component';
+import { BulkEmailType } from '@shared/enums/bulk-email-type';
 
 @Component({
   selector: 'app-adjudication-container',
@@ -148,7 +148,7 @@ export class AdjudicationContainerComponent implements OnInit {
         const response = { action };
         return (action.note)
           ? this.adjudicationResource.createAdjudicatorNote(enrolleeId, action.note, false)
-            .pipe(map((note: EnrolleeNote) => ({note, ...response})))
+            .pipe(map((note: EnrolleeNote) => ({ note, ...response })))
           : of(response);
       }),
       exhaustMap((response: { note: EnrolleeNote, action: AssignAction }) => {
@@ -287,6 +287,26 @@ export class AdjudicationContainerComponent implements OnInit {
       });
   }
 
+  public onCancelToa(enrolleeId: number) {
+    const data: DialogOptions = {
+      title: 'Cancel TOA Assignment',
+      message: 'Are you sure you want to cancel this TOA assignment and move the enrollee back into Under Review?',
+      actionType: 'warn',
+      actionText: 'Cancel TOA Assignment',
+      component: NoteComponent,
+    };
+
+    this.busy = this.dialog.open(ConfirmDialogComponent, { data })
+      .afterClosed()
+      .pipe(
+        this.adjudicationActionPipe(enrolleeId, SubmissionAction.CANCEL_TOA)
+      )
+      .subscribe((enableEnrollee: HttpEnrollee) => {
+        this.updateEnrollee(enableEnrollee);
+        this.action.emit();
+      });
+  }
+
   public onRerunRules(enrolleeId: number) {
     const data: DialogOptions = {
       title: 'Rerun Rules',
@@ -372,7 +392,7 @@ export class AdjudicationContainerComponent implements OnInit {
       title: 'Send Email - Bulk Actions'
     };
     this.busy = this.dialog.open(SendBulkEmailComponent, { data })
-    .afterClosed()
+      .afterClosed()
       .pipe(
         exhaustMap((bulkEmailType: BulkEmailType) =>
           bulkEmailType
@@ -380,11 +400,11 @@ export class AdjudicationContainerComponent implements OnInit {
             : EMPTY
         )
       )
-    .subscribe((emails: string[]) => {
-      emails.length
-        ? this.utilsService.mailTo(emails.join(';'))
-        : this.toastService.openErrorToast('No enrollees found for email type.');
-    });
+      .subscribe((emails: string[]) => {
+        emails.length
+          ? this.utilsService.mailTo(emails.join(';'))
+          : this.toastService.openErrorToast('No enrollees found for email type.');
+      });
   }
 
   public ngOnInit() {

--- a/prime-angular-frontend/src/app/modules/adjudication/shared/components/adjudicator-actions/adjudicator-actions.component.html
+++ b/prime-angular-frontend/src/app/modules/adjudication/shared/components/adjudicator-actions/adjudicator-actions.component.html
@@ -67,6 +67,13 @@
       <span>Enable Editing</span>
     </button>
     <button mat-menu-item
+            [disabled]="!(Role.APPROVE_ENROLLEE | inRole)"
+            *ngIf="enrollee.currentStatusCode === EnrolmentStatus.REQUIRES_TOA"
+            (click)="onCancelToa()">
+      <mat-icon>error_outline</mat-icon>
+      <span>Cancel TOA Assignment</span>
+    </button>
+    <button mat-menu-item
             [disabled]="!(Role.MANAGE_ENROLLEE | inRole)"
             (click)="onToggleManualAdj()">
       <mat-icon>flag</mat-icon>

--- a/prime-angular-frontend/src/app/modules/adjudication/shared/components/adjudicator-actions/adjudicator-actions.component.ts
+++ b/prime-angular-frontend/src/app/modules/adjudication/shared/components/adjudicator-actions/adjudicator-actions.component.ts
@@ -31,6 +31,7 @@ export class AdjudicatorActionsComponent implements OnInit {
   @Output() public enableEnrollee: EventEmitter<number>;
   @Output() public toggleManualAdj: EventEmitter<{ enrolleeId: number, alwaysManual: boolean }>;
   @Output() public enableEditing: EventEmitter<number>;
+  @Output() public cancelToa: EventEmitter<number>;
   @Output() public rerunRules: EventEmitter<number>;
   @Output() public delete: EventEmitter<number>;
   @Output() public route: EventEmitter<string | (string | number)[]>;
@@ -56,6 +57,7 @@ export class AdjudicatorActionsComponent implements OnInit {
     this.unlock = new EventEmitter<number>();
     this.enableEnrollee = new EventEmitter<number>();
     this.enableEditing = new EventEmitter<number>();
+    this.cancelToa = new EventEmitter<number>();
     this.rerunRules = new EventEmitter<number>();
     this.delete = new EventEmitter<number>();
     this.assignToa = new EventEmitter<{ enrolleeId: number, agreementType: AgreementType }>();
@@ -123,6 +125,12 @@ export class AdjudicatorActionsComponent implements OnInit {
   public onEnableEditing() {
     if (this.permissionService.hasRoles(Role.APPROVE_ENROLLEE)) {
       this.enableEditing.emit(this.enrollee.id);
+    }
+  }
+
+  public onCancelToa() {
+    if (this.permissionService.hasRoles(Role.APPROVE_ENROLLEE)) {
+      this.cancelToa.emit(this.enrollee.id);
     }
   }
 

--- a/prime-angular-frontend/src/app/shared/enums/submission-action.enum.ts
+++ b/prime-angular-frontend/src/app/shared/enums/submission-action.enum.ts
@@ -3,6 +3,7 @@ export enum SubmissionAction {
   ACCEPT_TOA = 'accept-toa',
   DECLINE_TOA = 'decline-toa',
   ENABLE_EDITING = 'enable-editing',
+  CANCEL_TOA = 'cancel-toa',
   LOCK_PROFILE = 'lock-profile',
   DECLINE_PROFILE = 'decline-profile',
   RERUN_RULES = 'rerun-rules',

--- a/prime-dotnet-webapi/Controllers/SubmissionsController.cs
+++ b/prime-dotnet-webapi/Controllers/SubmissionsController.cs
@@ -150,6 +150,23 @@ namespace Prime.Controllers
             return await SubmissionActionInternal(enrolleeId, SubmissionAction.EnableEditing);
         }
 
+        // POST: api/enrollees/5/submission/cancel-toa
+        /// <summary>
+        /// Puts the Enrolle back into Under Review from Requires TOA.
+        /// </summary>
+        /// <param name="enrolleeId"></param>
+        [HttpPost("{enrolleeId}/submission/cancel-toa", Name = nameof(CancelToaAssignment))]
+        [Authorize(Roles = Roles.ApproveEnrollee)]
+        [ProducesResponseType(typeof(ApiBadRequestResponse), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ApiMessageResponse), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ApiResultResponse<EnrolleeViewModel>), StatusCodes.Status200OK)]
+        public async Task<ActionResult> CancelToaAssignment(int enrolleeId)
+        {
+            return await SubmissionActionInternal(enrolleeId, SubmissionAction.CancelToaAssignment);
+        }
+
         // POST: api/enrollees/5/submission/lock-profile
         /// <summary>
         /// Locks the Enrolle's profile.

--- a/prime-dotnet-webapi/Engines/SubmissionStateEngine.cs
+++ b/prime-dotnet-webapi/Engines/SubmissionStateEngine.cs
@@ -11,25 +11,26 @@ namespace Prime.Engines
 
             return (currentStatus.GetStatusType(), action) switch
             {
-                (StatusType.Editable, SubmissionAction.LockProfile)       => true,
-                (StatusType.Editable, SubmissionAction.DeclineProfile)    => true,
+                (StatusType.Editable, SubmissionAction.LockProfile)             => true,
+                (StatusType.Editable, SubmissionAction.DeclineProfile)          => true,
 
-                (StatusType.UnderReview, SubmissionAction.Approve)        => true,
-                (StatusType.UnderReview, SubmissionAction.EnableEditing)  => true,
-                (StatusType.UnderReview, SubmissionAction.LockProfile)    => true,
-                (StatusType.UnderReview, SubmissionAction.DeclineProfile) => true,
-                (StatusType.UnderReview, SubmissionAction.RerunRules)     => true,
+                (StatusType.UnderReview, SubmissionAction.Approve)              => true,
+                (StatusType.UnderReview, SubmissionAction.EnableEditing)        => true,
+                (StatusType.UnderReview, SubmissionAction.LockProfile)          => true,
+                (StatusType.UnderReview, SubmissionAction.DeclineProfile)       => true,
+                (StatusType.UnderReview, SubmissionAction.RerunRules)           => true,
 
-                (StatusType.RequiresToa, SubmissionAction.AcceptToa)      => true,
-                (StatusType.RequiresToa, SubmissionAction.DeclineToa)     => true,
-                (StatusType.RequiresToa, SubmissionAction.EnableEditing)  => true,
-                (StatusType.RequiresToa, SubmissionAction.LockProfile)    => true,
-                (StatusType.RequiresToa, SubmissionAction.DeclineProfile) => true,
+                (StatusType.RequiresToa, SubmissionAction.AcceptToa)            => true,
+                (StatusType.RequiresToa, SubmissionAction.DeclineToa)           => true,
+                (StatusType.RequiresToa, SubmissionAction.EnableEditing)        => true,
+                (StatusType.RequiresToa, SubmissionAction.LockProfile)          => true,
+                (StatusType.RequiresToa, SubmissionAction.DeclineProfile)       => true,
+                (StatusType.RequiresToa, SubmissionAction.CancelToaAssignment)  => true,
 
-                (StatusType.Locked, SubmissionAction.EnableEditing)       => true,
-                (StatusType.Locked, SubmissionAction.DeclineProfile)      => true,
+                (StatusType.Locked, SubmissionAction.EnableEditing)             => true,
+                (StatusType.Locked, SubmissionAction.DeclineProfile)            => true,
 
-                (StatusType.Declined, SubmissionAction.EnableEditing)     => true,
+                (StatusType.Declined, SubmissionAction.EnableEditing)           => true,
 
                 _ => false
             };

--- a/prime-dotnet-webapi/Models/Api/SubmissionAction.cs
+++ b/prime-dotnet-webapi/Models/Api/SubmissionAction.cs
@@ -8,6 +8,7 @@ namespace Prime.Models.Api
         EnableEditing,
         LockProfile,
         DeclineProfile,
-        RerunRules
+        RerunRules,
+        CancelToaAssignment
     }
 }

--- a/prime-dotnet-webapi/Services/SubmissionService.cs
+++ b/prime-dotnet-webapi/Services/SubmissionService.cs
@@ -169,6 +169,10 @@ namespace Prime.Services
                     await RerunRulesAsync(enrollee);
                     break;
 
+                case SubmissionAction.CancelToaAssignment:
+                    await CancelToaAssignmentAsync(enrollee);
+                    break;
+
                 default:
                     throw new InvalidOperationException($"Action {action} is not recognized in {nameof(HandleSubmissionActionAsync)}");
             }
@@ -283,6 +287,17 @@ namespace Prime.Services
             await _businessEventService.CreateStatusChangeEventAsync(enrollee.Id, "Adjudicator manually ran the enrollee application rules");
             await ProcessEnrolleeApplicationRules(enrollee.Id);
             await _context.SaveChangesAsync();
+            await _enrolleeService.RemoveNotificationsAsync(enrollee.Id);
+        }
+
+        private async Task CancelToaAssignmentAsync(Enrollee enrollee)
+        {
+            var newStatus = enrollee.AddEnrolmentStatus(StatusType.UnderReview);
+            newStatus.AddStatusReason(StatusReasonType.Manual, "Adjudicator cancelled TOA assignment");
+            await _enrolleeSubmissionService.CreateEnrolleeSubmissionAsync(enrollee.Id, false);
+            await _context.SaveChangesAsync();
+
+            await _businessEventService.CreateStatusChangeEventAsync(enrollee.Id, "Adjudicator cancelled TOA assignment");
             await _enrolleeService.RemoveNotificationsAsync(enrollee.Id);
         }
 

--- a/prime-dotnet-webapi/Services/interfaces/IEnrolleeSubmissionService.cs
+++ b/prime-dotnet-webapi/Services/interfaces/IEnrolleeSubmissionService.cs
@@ -14,6 +14,6 @@ namespace Prime.Services
 
         Task<Submission> GetEnrolleeSubmissionBeforeDateAsync(int enrolleeId, DateTimeOffset dateTime);
 
-        Task CreateEnrolleeSubmissionAsync(int enrolleeId);
+        Task CreateEnrolleeSubmissionAsync(int enrolleeId, bool assignAgreement = true);
     }
 }


### PR DESCRIPTION
Ability for adjudicators to undo a miss-assigned TOA type, usually (but not exclusively) after manual adjudication.

Slightly waiting on if additional enrollee notification is required.