### PR TITLE
Use Effective Date instead of Updated Date in TOA Maintenance page

### DIFF
--- a/prime-angular-frontend/src/app/modules/adjudication/pages/enrollee-toa-maintenance-list-page/enrollee-toa-maintenance-list-page.component.ts
+++ b/prime-angular-frontend/src/app/modules/adjudication/pages/enrollee-toa-maintenance-list-page/enrollee-toa-maintenance-list-page.component.ts
@@ -45,7 +45,7 @@ export class EnrolleeToaMaintenanceListPageComponent implements OnInit {
     return [
       {
         key: 'Last Modified',
-        value: this.formatDatePipe.transform(agreementVersion.updatedDate)
+        value: this.formatDatePipe.transform(agreementVersion.effectiveDate)
       }
     ];
   }

--- a/prime-angular-frontend/src/app/modules/adjudication/pages/enrollee-toa-maintenance-page/enrollee-toa-maintenance-page.component.html
+++ b/prime-angular-frontend/src/app/modules/adjudication/pages/enrollee-toa-maintenance-page/enrollee-toa-maintenance-page.component.html
@@ -21,7 +21,7 @@
           </mat-card-title>
         </mat-card-header>
         <mat-card-content class="ml-3">
-          Last modified {{ av.updatedDate | formatDate | default }}
+          Last modified {{ av.effectiveDate | formatDate | default }}
         </mat-card-content>
         <mat-card-actions class="d-flex justify-content-end">
           <button mat-stroked-button

--- a/prime-angular-frontend/src/app/shared/models/agreement-version.model.ts
+++ b/prime-angular-frontend/src/app/shared/models/agreement-version.model.ts
@@ -2,7 +2,7 @@ import { AgreementType } from '@shared/enums/agreement-type.enum';
 
 export interface AgreementVersion {
   id: number;
-  updatedDate: string;
+  effectiveDate: string;
   text: string;
   agreementType: AgreementType;
 }

--- a/prime-dotnet-webapi/ViewModels/Agreements/AgreementVersionListViewModel.cs
+++ b/prime-dotnet-webapi/ViewModels/Agreements/AgreementVersionListViewModel.cs
@@ -6,7 +6,7 @@ namespace Prime.ViewModels
     public class AgreementVersionListViewModel
     {
         public int Id { get; set; }
-        public DateTimeOffset UpdatedDate { get; set; }
+        public DateTimeOffset EffectiveDate { get; set; }
         public AgreementType AgreementType { get; set; }
     }
 }

--- a/prime-dotnet-webapi/ViewModels/Agreements/AgreementVersionViewModel.cs
+++ b/prime-dotnet-webapi/ViewModels/Agreements/AgreementVersionViewModel.cs
@@ -6,7 +6,7 @@ namespace Prime.ViewModels
     public class AgreementVersionViewModel
     {
         public int Id { get; set; }
-        public DateTimeOffset UpdatedDate { get; set; }
+        public DateTimeOffset EffectiveDate { get; set; }
         public AgreementType AgreementType { get; set; }
         public string Text { get; set; }
     }

--- a/prime-dotnet-webapi/ViewModels/AutoMapping.cs
+++ b/prime-dotnet-webapi/ViewModels/AutoMapping.cs
@@ -94,10 +94,8 @@ public class AutoMapping : Profile
             .IncludeMembers(src => src.Party);
         CreateMap<Party, AuthorizedUserViewModel>();
 
-        CreateMap<AgreementVersion, AgreementVersionViewModel>()
-            .ForMember(dest => dest.UpdatedDate, opt => opt.MapFrom(src => src.UpdatedTimeStamp));
-        CreateMap<AgreementVersion, AgreementVersionListViewModel>()
-            .ForMember(dest => dest.UpdatedDate, opt => opt.MapFrom(src => src.UpdatedTimeStamp));
+        CreateMap<AgreementVersion, AgreementVersionViewModel>();
+        CreateMap<AgreementVersion, AgreementVersionListViewModel>();
 
         CreateMap<Contact, ContactViewModel>()
             .ReverseMap();


### PR DESCRIPTION
The "Last Modified Date" on the TOA maintenance page shows September 19th, 2019 for every TOA. This is because it comes from the "Updated Date" column, which is set to Sept 19th for every version. A far more useful date for the current state of the app is the "Effective Date", which is the date that the Agreement Version became effective in the application.

![image](https://user-images.githubusercontent.com/39168456/122828300-5652de00-d29a-11eb-9ce9-d18d4b0c9a22.png)
 
 Becomes
 
![image](https://user-images.githubusercontent.com/39168456/122828375-72567f80-d29a-11eb-8fbd-7bffdb8caa89.png)

We can revisit what data should be displayed on the cards when/if adjudicators have the ability to edit agreements.