### PR TITLE
Remove direct use of environment for config

### DIFF
--- a/prime-angular-frontend/src/app/core/modules/keycloak/keycloak-init.service.ts
+++ b/prime-angular-frontend/src/app/core/modules/keycloak/keycloak-init.service.ts
@@ -1,10 +1,10 @@
-import { Injectable } from '@angular/core';
+import { Inject, Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { Location } from '@angular/common';
 
 import { KeycloakService } from 'keycloak-angular';
 
-import { environment } from '@env/environment';
+import { APP_CONFIG, AppConfig } from 'app/app-config.module';
 import { ToastService } from '@core/services/toast.service';
 import { AuthRoutes } from '@auth/auth.routes';
 import { GisEnrolmentRoutes } from '@gis/gis-enrolment.routes';
@@ -14,6 +14,7 @@ import { GisEnrolmentRoutes } from '@gis/gis-enrolment.routes';
 })
 export class KeycloakInitService {
   constructor(
+    @Inject(APP_CONFIG) private config: AppConfig,
     private router: Router,
     private location: Location,
     private keycloakService: KeycloakService,
@@ -39,8 +40,8 @@ export class KeycloakInitService {
 
   private getKeycloakOptions() {
     return (this.isMohKeycloak())
-      ? environment.mohKeycloakConfig
-      : environment.keycloakConfig;
+      ? this.config.mohKeycloakConfig
+      : this.config.keycloakConfig;
   }
 
   private isMohKeycloak() {

--- a/prime-angular-frontend/src/app/core/services/console-logger.service.ts
+++ b/prime-angular-frontend/src/app/core/services/console-logger.service.ts
@@ -1,13 +1,15 @@
-import { Injectable } from '@angular/core';
+import { Inject, Injectable } from '@angular/core';
 
-import { environment } from '@env/environment';
+import { APP_CONFIG, AppConfig } from 'app/app-config.module';
 import { AbstractLoggerService } from '@core/services/abstract-logger.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class ConsoleLoggerService extends AbstractLoggerService {
-  constructor() {
+  constructor(
+    @Inject(APP_CONFIG) private config: AppConfig
+  ) {
     super();
   }
 
@@ -24,7 +26,7 @@ export class ConsoleLoggerService extends AbstractLoggerService {
    * Prints the logging information, but ONLY if not in production.
    */
   protected send(type: string, params: { msg?: string, data?: any[] }) {
-    if (!environment.production || type === 'error' || type === 'warn') {
+    if (this.config.environmentName !== 'prod' || type === 'error' || type === 'warn') {
 
       const message = this.colorize(type, params.msg);
 

--- a/prime-angular-frontend/src/app/modules/auth/shared/guards/authentication.guard.ts
+++ b/prime-angular-frontend/src/app/modules/auth/shared/guards/authentication.guard.ts
@@ -1,7 +1,6 @@
 import { Injectable, Inject } from '@angular/core';
 import { Router } from '@angular/router';
 
-import { environment } from '@env/environment';
 import { APP_CONFIG, AppConfig } from 'app/app-config.module';
 import { ConfigService } from '@config/config.service';
 import { BaseGuard } from '@core/guards/base.guard';
@@ -48,7 +47,7 @@ export class AuthenticationGuard extends BaseGuard {
         // Capture the user's current location, and provide it to
         // Keycloak to redirect the user to where they originated
         // once authenticated
-        const redirectUri = `${environment.loginRedirectUrl}${routePath}`;
+        const redirectUri = `${this.config.loginRedirectUrl}${routePath}`;
         const idpHint = (adminRoutes.includes(targetModule))
           ? IdentityProviderEnum.IDIR
           : (gisRoutes.includes(targetModule))

--- a/prime-angular-frontend/src/app/shared/components/document-upload/document-upload/document-upload.component.ts
+++ b/prime-angular-frontend/src/app/shared/components/document-upload/document-upload/document-upload.component.ts
@@ -7,8 +7,6 @@ import { FilePondPluginFileValidateSizeProps } from 'filepond-plugin-file-valida
 import { FilePondComponent } from 'ngx-filepond/filepond.component';
 import tus from 'tus-js-client';
 
-import { environment } from '@env/environment';
-
 import { ConsoleLoggerService } from '@core/services/console-logger.service';
 import { AccessTokenService } from '@auth/shared/services/access-token.service';
 import { APP_CONFIG, AppConfig } from '../../../../app-config.module';
@@ -152,7 +150,7 @@ export class DocumentUploadComponent implements OnInit {
     };
 
     return {
-      url: `${environment.documentManagerUrl}/documents/uploads`,
+      url: `${this.config.documentManagerUrl}/documents/uploads`,
       process,
     };
   }

--- a/prime-angular-frontend/src/environments/config-map.model.ts
+++ b/prime-angular-frontend/src/environments/config-map.model.ts
@@ -8,4 +8,5 @@ export class ConfigMap {
   loginRedirectUrl: string;
   documentManagerUrl: string;
   keycloakConfig: KeycloakOptions;
+  mohKeycloakConfig: KeycloakOptions;
 }

--- a/prime-angular-frontend/src/environments/environment.model.ts
+++ b/prime-angular-frontend/src/environments/environment.model.ts
@@ -1,15 +1,11 @@
-import { KeycloakOptions } from 'keycloak-angular';
 import { ConfigMap } from '@env/config-map.model';
 
 export type environmentName = 'prod' | 'test' | 'dev' | 'local';
 
 export class AppEnvironment extends ConfigMap {
+  // Only indicates that Angular has been built using --prod
   production: boolean;
   version: string;
-  environmentName: environmentName;
-  apiEndpoint: string;
-  loginRedirectUrl: string;
-  documentManagerUrl: string;
   prime: {
     displayPhone: string;
     phone: string;
@@ -19,6 +15,4 @@ export class AppEnvironment extends ConfigMap {
   phoneNumbers: {
     director: string;
   };
-  keycloakConfig: KeycloakOptions;
-  mohKeycloakConfig: KeycloakOptions;
 }

--- a/prime-angular-frontend/src/main.ts
+++ b/prime-angular-frontend/src/main.ts
@@ -17,6 +17,7 @@ fetch('/assets/config-map.json')
     let appConfig = defaultAppConfig;
 
     if (configMap) {
+      // TODO mohKeyCloakConfig will eventually have configuration applied throughout the environments
       const { keycloakConfig: { config }, ...root } = configMap;
       appConfig = { ...appConfig, ...root };
       appConfig.keycloakConfig.config = config;


### PR DESCRIPTION
With the recent update to allow swapping of environment variables through OCP4 config maps we should not be access environment files directly, and should only use config injection token for access to these values.  

Will create another update that essentially removes import access of the environment file, but this interim update will fix the issues that will occur outside of our local environments.