### PR TITLE
[OPS] Add resource limits to PR deployments

### DIFF
--- a/infrastructure/prime-app-ephemeral-template.yml
+++ b/infrastructure/prime-app-ephemeral-template.yml
@@ -132,6 +132,13 @@ objects:
             env:
               - name: DOCUMENT_MANAGER_URL
                 value: https://${SVC_NAME}${URL_STUB}/api/docman
+            resources:
+              limits:
+                cpu: 50m
+                memory: 50MiB
+              requests:
+                cpu: 15m
+                memory: 10MiB
             readinessProbe:
               httpGet:
                 path: /
@@ -607,6 +614,13 @@ objects:
                 protocol: TCP
               - containerPort: 8080
                 protocol: TCP
+            resources:
+              limits:
+                cpu: 50m
+                memory: 1GiB
+              requests:
+                cpu: 15m
+                memory: 500MiB
             startupProbe:
               httpGet:
                 path: /api/healthcheck
@@ -870,6 +884,13 @@ objects:
                   secretKeyRef:
                     name: pr-database-secrets
                     key: database-password
+            resources:
+              limits:
+                cpu: 25m
+                memory: 128MiB
+              requests:
+                cpu: 10m
+                memory: 28MiB
             volumeMounts:
             # Mount Document Manager to PVC
               - mountPath: /app/
@@ -997,7 +1018,11 @@ objects:
                 name: postgresql
             resources:
               limits:
+                cpu: 50m
                 memory: ${POSTGRES_MEMORY_LIMIT}
+              requests:
+                cpu: 10m
+                memory: 100MiB            
             securityContext:
               capabilities: {}
               privileged: false

--- a/infrastructure/prime-app-ephemeral-template.yml
+++ b/infrastructure/prime-app-ephemeral-template.yml
@@ -1113,7 +1113,11 @@ objects:
         containers:
           - resources:
               limits:
-                memory: 512Mi
+                cpu: 25m
+                memory: 100Mi
+              requests:
+                cpu: 5m
+                memory: 50Mi 
             readinessProbe:
               exec:
                 command:

--- a/infrastructure/prime-app-ephemeral-template.yml
+++ b/infrastructure/prime-app-ephemeral-template.yml
@@ -135,10 +135,10 @@ objects:
             resources:
               limits:
                 cpu: 50m
-                memory: 50MiB
+                memory: 50Mi
               requests:
                 cpu: 15m
-                memory: 10MiB
+                memory: 10Mi
             readinessProbe:
               httpGet:
                 path: /
@@ -620,7 +620,7 @@ objects:
                 memory: 1GiB
               requests:
                 cpu: 15m
-                memory: 500MiB
+                memory: 500Mi
             startupProbe:
               httpGet:
                 path: /api/healthcheck
@@ -887,10 +887,10 @@ objects:
             resources:
               limits:
                 cpu: 25m
-                memory: 128MiB
+                memory: 128Mi
               requests:
                 cpu: 10m
-                memory: 28MiB
+                memory: 28Mi
             volumeMounts:
             # Mount Document Manager to PVC
               - mountPath: /app/
@@ -1022,7 +1022,7 @@ objects:
                 memory: ${POSTGRES_MEMORY_LIMIT}
               requests:
                 cpu: 10m
-                memory: 100MiB            
+                memory: 100Mi            
             securityContext:
               capabilities: {}
               privileged: false

--- a/infrastructure/prime-app-ephemeral-template.yml
+++ b/infrastructure/prime-app-ephemeral-template.yml
@@ -617,7 +617,7 @@ objects:
             resources:
               limits:
                 cpu: 50m
-                memory: 1GiB
+                memory: 1Gi
               requests:
                 cpu: 15m
                 memory: 500Mi


### PR DESCRIPTION
# Adding resource requests and limits
This should allow us to run more PR deployments simultaniously.

|   | _CPU_  | ______  |  _MEMORY_ |  ______ |
|---|---|---|---|---|
|   | **limit**  |  **request** | **limit**  |  **request** |
|  **frontend**  | 50m  |  15m | 50Mi  |  10Mi |
|  **webapi**  | 50m  |  15m | 1Gi  |  500Mi |
|  **docman**  | 25m  |  10m | 128Mi  |  28Mi |
|  **redis**  | 25m  |  5m | 100Mi  |  50Mi |
|  **postgres**  | 50m  |  10m | 512Mi  |  100Mi |
