### PR TITLE
Fix multiple enrollee call on admin view that wipes filter

### DIFF
--- a/prime-angular-frontend/src/app/modules/adjudication/shared/components/adjudication-container/adjudication-container.component.ts
+++ b/prime-angular-frontend/src/app/modules/adjudication/shared/components/adjudication-container/adjudication-container.component.ts
@@ -420,7 +420,11 @@ export class AdjudicationContainerComponent implements OnInit {
       .subscribe((queryParams: { [key: string]: any }) => this.getDataset(this.route.snapshot.params.id, queryParams));
     // url params could change due to jump action, subscribe to changes
     this.route.params
-      .subscribe((params) => this.getDataset(params.id, {}));
+      .subscribe((params) => {
+        if (params.id) {
+          this.getDataset(params.id, {});
+        }
+      });
   }
 
   protected getDataset(enrolleeId: number, queryParams: { search?: string, status?: number }) {


### PR DESCRIPTION
This bug only presents it self with large enrollee counts when the getEnrollees call takes time to return. On the enrollee page there was two calls being fired since we were watching the query params and the route params. So even though param.id was undefined we were then firing off a get all enrollees call. So the duplication in two spots caused the slower of the calls to return after the filtered call and then repopulate the data source with all enrollees.