### PR TITLE
PRIME-1844/1840 Add Technical Support Page to Health Auth Workflow + Contacts Update

### DIFF
--- a/prime-angular-frontend/package-lock.json
+++ b/prime-angular-frontend/package-lock.json
@@ -3609,41 +3609,41 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.30.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.30.0.tgz",
-      "integrity": "sha512-HJ0XuluSZSxeboLU7Q2VQ6eLlCwXPBOGnA7CqgBnz2Db3JRQYyBDJgQnop6TZ+rsbSx5gEdWhw4rE4mDa1FnZg==",
+      "version": "4.31.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.31.1.tgz",
+      "integrity": "sha512-dnVZDB6FhpIby6yVbHkwTKkn2ypjVIfAR9nh+kYsA/ZL0JlTsd22BiDjouotisY3Irmd3OW1qlk9EI5R8GrvRQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.30.0",
-        "@typescript-eslint/types": "4.30.0",
-        "@typescript-eslint/typescript-estree": "4.30.0",
+        "@typescript-eslint/scope-manager": "4.31.1",
+        "@typescript-eslint/types": "4.31.1",
+        "@typescript-eslint/typescript-estree": "4.31.1",
         "debug": "^4.3.1"
       },
       "dependencies": {
         "@typescript-eslint/scope-manager": {
-          "version": "4.30.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.30.0.tgz",
-          "integrity": "sha512-VJ/jAXovxNh7rIXCQbYhkyV2Y3Ac/0cVHP/FruTJSAUUm4Oacmn/nkN5zfWmWFEanN4ggP0vJSHOeajtHq3f8A==",
+          "version": "4.31.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.31.1.tgz",
+          "integrity": "sha512-N1Uhn6SqNtU2XpFSkD4oA+F0PfKdWHyr4bTX0xTj8NRx1314gBDRL1LUuZd5+L3oP+wo6hCbZpaa1in6SwMcVQ==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "4.30.0",
-            "@typescript-eslint/visitor-keys": "4.30.0"
+            "@typescript-eslint/types": "4.31.1",
+            "@typescript-eslint/visitor-keys": "4.31.1"
           }
         },
         "@typescript-eslint/types": {
-          "version": "4.30.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.30.0.tgz",
-          "integrity": "sha512-YKldqbNU9K4WpTNwBqtAerQKLLW/X2A/j4yw92e3ZJYLx+BpKLeheyzoPfzIXHfM8BXfoleTdiYwpsvVPvHrDw==",
+          "version": "4.31.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.31.1.tgz",
+          "integrity": "sha512-kixltt51ZJGKENNW88IY5MYqTBA8FR0Md8QdGbJD2pKZ+D5IvxjTYDNtJPDxFBiXmka2aJsITdB1BtO1fsgmsQ==",
           "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-          "version": "4.30.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.30.0.tgz",
-          "integrity": "sha512-6WN7UFYvykr/U0Qgy4kz48iGPWILvYL34xXJxvDQeiRE018B7POspNRVtAZscWntEPZpFCx4hcz/XBT+erenfg==",
+          "version": "4.31.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.31.1.tgz",
+          "integrity": "sha512-EGHkbsUvjFrvRnusk6yFGqrqMBTue5E5ROnS5puj3laGQPasVUgwhrxfcgkdHNFECHAewpvELE1Gjv0XO3mdWg==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "4.30.0",
-            "@typescript-eslint/visitor-keys": "4.30.0",
+            "@typescript-eslint/types": "4.31.1",
+            "@typescript-eslint/visitor-keys": "4.31.1",
             "debug": "^4.3.1",
             "globby": "^11.0.3",
             "is-glob": "^4.0.1",
@@ -3652,12 +3652,12 @@
           }
         },
         "@typescript-eslint/visitor-keys": {
-          "version": "4.30.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.30.0.tgz",
-          "integrity": "sha512-pNaaxDt/Ol/+JZwzP7MqWc8PJQTUhZwoee/PVlQ+iYoYhagccvoHnC9e4l+C/krQYYkENxznhVSDwClIbZVxRw==",
+          "version": "4.31.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.31.1.tgz",
+          "integrity": "sha512-PCncP8hEqKw6SOJY+3St4LVtoZpPPn+Zlpm7KW5xnviMhdqcsBty4Lsg4J/VECpJjw1CkROaZhH4B8M1OfnXTQ==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "4.30.0",
+            "@typescript-eslint/types": "4.31.1",
             "eslint-visitor-keys": "^2.0.0"
           }
         },

--- a/prime-angular-frontend/package.json
+++ b/prime-angular-frontend/package.json
@@ -70,7 +70,7 @@
     "@types/smoothscroll-polyfill": "^0.3.1",
     "@types/tus-js-client": "^1.8.0",
     "@typescript-eslint/eslint-plugin": "4.31.0",
-    "@typescript-eslint/parser": "4.30.0",
+    "@typescript-eslint/parser": "4.31.1",
     "eslint": "^7.26.0",
     "faker": "^4.1.0",
     "jasmine-core": "~3.6.0",

--- a/prime-angular-frontend/src/app/core/resources/health-authority-resource.service.ts
+++ b/prime-angular-frontend/src/app/core/resources/health-authority-resource.service.ts
@@ -26,6 +26,7 @@ import { SiteAddressForm } from '@health-auth/pages/site-address-page/site-addre
 import { HoursOperationForm } from '@health-auth/pages/hours-operation-page/hours-operation-form.model';
 import { RemoteUsersForm } from '@health-auth/pages/remote-users-page/remote-users-form.model';
 import { AdministratorForm } from '@health-auth/pages/administrator-page/administrator-form.model';
+import { TechnicalSupportForm } from '@health-auth/pages/technical-support-page/technical-support-form.model';
 
 @Injectable({
   providedIn: 'root'
@@ -355,6 +356,18 @@ export class HealthAuthorityResource {
         catchError((error: any) => {
           this.toastService.openErrorToast('Health authority administrator could not be updated');
           this.logger.error('[Core] HealthAuthorityResource::updateHealthAuthoritySiteAdministrator error has occurred: ', error);
+          throw error;
+        })
+      );
+  }
+
+  public updateHealthAuthorityTechnicalSupport(healthAuthId: number, siteId: number, payload: TechnicalSupportForm): NoContent {
+    return this.apiResource.put<HealthAuthority>(`health-authorities/${healthAuthId}/sites/${siteId}/technical-support`, payload)
+      .pipe(
+        NoContentResponse,
+        catchError((error: any) => {
+          this.toastService.openErrorToast('Health authority technical support could not be updated');
+          this.logger.error('[Core] HealthAuthorityResource::updateHealthAuthorityTechnicalSupport error has occurred: ', error);
           throw error;
         })
       );

--- a/prime-angular-frontend/src/app/core/resources/health-authority-resource.service.ts
+++ b/prime-angular-frontend/src/app/core/resources/health-authority-resource.service.ts
@@ -349,7 +349,7 @@ export class HealthAuthorityResource {
       );
   }
 
-  public updateHealthAuthorityPharmanetAdministrator(healthAuthId: number, siteId: number, payload: AdministratorForm): NoContent {
+  public updateHealthAuthoritySitePharmanetAdministrator(healthAuthId: number, siteId: number, payload: AdministratorForm): NoContent {
     return this.apiResource.put<HealthAuthority>(`health-authorities/${healthAuthId}/sites/${siteId}/administrator`, payload)
       .pipe(
         NoContentResponse,
@@ -361,7 +361,7 @@ export class HealthAuthorityResource {
       );
   }
 
-  public updateHealthAuthorityTechnicalSupport(healthAuthId: number, siteId: number, payload: TechnicalSupportForm): NoContent {
+  public updateHealthAuthoritySiteTechnicalSupport(healthAuthId: number, siteId: number, payload: TechnicalSupportForm): NoContent {
     return this.apiResource.put<HealthAuthority>(`health-authorities/${healthAuthId}/sites/${siteId}/technical-support`, payload)
       .pipe(
         NoContentResponse,

--- a/prime-angular-frontend/src/app/lib/utils/email-utils.class.spec.ts
+++ b/prime-angular-frontend/src/app/lib/utils/email-utils.class.spec.ts
@@ -1,6 +1,6 @@
 import { EmailUtils } from '@lib/utils/email-utils.class';
 
-fdescribe('EmailUtils', () => {
+describe('EmailUtils', () => {
   const util = EmailUtils;
 
   beforeEach(() => { });

--- a/prime-angular-frontend/src/app/modules/adjudication/adjudication-routing.module.ts
+++ b/prime-angular-frontend/src/app/modules/adjudication/adjudication-routing.module.ts
@@ -332,7 +332,7 @@ const routes: Routes = [
               {
                 path: AdjudicationRoutes.HEALTH_AUTH_TECHNICAL_SUPPORTS,
                 component: TechnicalSupportsPageComponent,
-                data: { title: 'Technical Support Contact(s)' }
+                data: { title: 'Technical Support(s)' }
               },
               {
                 path: AdjudicationRoutes.HEALTH_AUTH_ADMINISTRATORS,

--- a/prime-angular-frontend/src/app/modules/adjudication/pages/health-authorities/privacy-office-page/privacy-office-page.component.ts
+++ b/prime-angular-frontend/src/app/modules/adjudication/pages/health-authorities/privacy-office-page/privacy-office-page.component.ts
@@ -3,8 +3,6 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { FormBuilder } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 
-import { Observable } from 'rxjs';
-
 import { RouteUtils } from '@lib/utils/route-utils.class';
 import { AbstractEnrolmentPage } from '@lib/classes/abstract-enrolment-page.class';
 import { HealthAuthorityResource } from '@core/resources/health-authority-resource.service';

--- a/prime-angular-frontend/src/app/modules/adjudication/shared/components/adjudicator-actions/adjudicator-actions.component.ts
+++ b/prime-angular-frontend/src/app/modules/adjudication/shared/components/adjudicator-actions/adjudicator-actions.component.ts
@@ -176,11 +176,9 @@ export class AdjudicatorActionsComponent implements OnInit, OnChanges {
       }
 
       // Disable or enable based on enrollee status
-      if (changes.enrollee.currentValue.currentStatusCode === EnrolmentStatusEnum.UNDER_REVIEW) {
-        this.assignedTOAType.enable({ emitEvent: false });
-      } else {
-        this.assignedTOAType.disable({ emitEvent: false });
-      }
+      (changes.enrollee.currentValue.currentStatusCode === EnrolmentStatusEnum.UNDER_REVIEW)
+        ? this.assignedTOAType.enable({ emitEvent: false })
+        : this.assignedTOAType.disable({ emitEvent: false });
     }
   }
 

--- a/prime-angular-frontend/src/app/modules/health-auth-site-reg/health-auth-site-reg-routing.module.ts
+++ b/prime-angular-frontend/src/app/modules/health-auth-site-reg/health-auth-site-reg-routing.module.ts
@@ -23,6 +23,7 @@ import { HoursOperationPageComponent } from '@health-auth/pages/hours-operation-
 import { RemoteUsersPageComponent } from '@health-auth/pages/remote-users-page/remote-users-page.component';
 import { RemoteUserPageComponent } from '@health-auth/pages/remote-user-page/remote-user-page.component';
 import { AdministratorPageComponent } from '@health-auth/pages/administrator-page/administrator-page.component';
+import { TechnicalSupportPageComponent } from '@health-auth/pages/technical-support-page/technical-support-page.component';
 import { OverviewPageComponent } from '@health-auth/pages/overview-page/overview-page.component';
 
 const routes: Routes = [
@@ -146,6 +147,12 @@ const routes: Routes = [
             component: AdministratorPageComponent,
             canDeactivate: [CanDeactivateFormGuard],
             data: { title: 'PharmaNet Administrator' }
+          },
+          {
+            path: HealthAuthSiteRegRoutes.TECHNICAL_SUPPORT,
+            component: TechnicalSupportPageComponent,
+            canDeactivate: [CanDeactivateFormGuard],
+            data: { title: 'Technical Support' }
           },
           {
             path: HealthAuthSiteRegRoutes.SITE_OVERVIEW,

--- a/prime-angular-frontend/src/app/modules/health-auth-site-reg/health-auth-site-reg-routing.module.ts
+++ b/prime-angular-frontend/src/app/modules/health-auth-site-reg/health-auth-site-reg-routing.module.ts
@@ -143,7 +143,7 @@ const routes: Routes = [
             ]
           },
           {
-            path: HealthAuthSiteRegRoutes.SITE_ADMINISTRATOR,
+            path: HealthAuthSiteRegRoutes.ADMINISTRATOR,
             component: AdministratorPageComponent,
             canDeactivate: [CanDeactivateFormGuard],
             data: { title: 'PharmaNet Administrator' }

--- a/prime-angular-frontend/src/app/modules/health-auth-site-reg/health-auth-site-reg.module.ts
+++ b/prime-angular-frontend/src/app/modules/health-auth-site-reg/health-auth-site-reg.module.ts
@@ -28,6 +28,8 @@ import { RemoteUsersOverviewComponent } from './pages/remote-users-page/remote-u
 import { RemoteUserPageComponent } from './pages/remote-user-page/remote-user-page.component';
 import { AdministratorPageComponent } from './pages/administrator-page/administrator-page.component';
 import { AdministratorOverviewComponent } from './pages/administrator-page/administrator-overview.component';
+import { TechnicalSupportPageComponent } from './pages/technical-support-page/technical-support-page.component';
+import { TechnicalSupportOverviewComponent } from './pages/technical-support-page/technical-support-overview.component';
 import { OverviewPageComponent } from './pages/overview-page/overview-page.component';
 
 @NgModule({
@@ -55,6 +57,8 @@ import { OverviewPageComponent } from './pages/overview-page/overview-page.compo
     RemoteUserPageComponent,
     AdministratorPageComponent,
     AdministratorOverviewComponent,
+    TechnicalSupportPageComponent,
+    TechnicalSupportOverviewComponent,
     OverviewPageComponent
   ],
   imports: [

--- a/prime-angular-frontend/src/app/modules/health-auth-site-reg/health-auth-site-reg.routes.ts
+++ b/prime-angular-frontend/src/app/modules/health-auth-site-reg/health-auth-site-reg.routes.ts
@@ -22,6 +22,7 @@ export class HealthAuthSiteRegRoutes {
   public static HOURS_OPERATION = 'hours-operation';
   public static REMOTE_USERS = 'remote-users';
   public static SITE_ADMINISTRATOR = 'site-administrator';
+  public static TECHNICAL_SUPPORT = 'technical-support';
   public static SITE_OVERVIEW = 'site-overview';
 
   public static routePath(route: string): string {
@@ -38,6 +39,7 @@ export class HealthAuthSiteRegRoutes {
       this.HOURS_OPERATION,
       this.REMOTE_USERS,
       this.SITE_ADMINISTRATOR,
+      this.TECHNICAL_SUPPORT,
       this.SITE_OVERVIEW
     ];
   }

--- a/prime-angular-frontend/src/app/modules/health-auth-site-reg/health-auth-site-reg.routes.ts
+++ b/prime-angular-frontend/src/app/modules/health-auth-site-reg/health-auth-site-reg.routes.ts
@@ -16,12 +16,12 @@ export class HealthAuthSiteRegRoutes {
   public static HEALTH_AUTHORITIES = 'health-authorities';
   public static SITES = 'sites';
   public static VENDOR = 'vendor';
-  public static HEALTH_AUTH_CARE_TYPE = 'health-auth-care-type';
   public static SITE_INFORMATION = 'site-information';
+  public static HEALTH_AUTH_CARE_TYPE = 'health-auth-care-type';
   public static SITE_ADDRESS = 'site-address';
   public static HOURS_OPERATION = 'hours-operation';
   public static REMOTE_USERS = 'remote-users';
-  public static SITE_ADMINISTRATOR = 'site-administrator';
+  public static ADMINISTRATOR = 'administrator';
   public static TECHNICAL_SUPPORT = 'technical-support';
   public static SITE_OVERVIEW = 'site-overview';
 
@@ -38,7 +38,7 @@ export class HealthAuthSiteRegRoutes {
       this.SITE_ADDRESS,
       this.HOURS_OPERATION,
       this.REMOTE_USERS,
-      this.SITE_ADMINISTRATOR,
+      this.ADMINISTRATOR,
       this.TECHNICAL_SUPPORT,
       this.SITE_OVERVIEW
     ];

--- a/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/administrator-page/administrator-form-state.class.ts
+++ b/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/administrator-page/administrator-form-state.class.ts
@@ -1,4 +1,4 @@
-import { FormBuilder, FormControl, Validators } from '@angular/forms';
+import { FormBuilder, Validators } from '@angular/forms';
 
 import { AbstractFormState } from '@lib/classes/abstract-form-state.class';
 

--- a/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/administrator-page/administrator-overview.component.spec.ts
+++ b/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/administrator-page/administrator-overview.component.spec.ts
@@ -17,8 +17,7 @@ describe('AdministratorOverviewComponent', () => {
         AdministratorOverviewComponent,
         FullnamePipe
       ]
-    })
-    .compileComponents();
+    }).compileComponents();
   });
 
   beforeEach(() => {

--- a/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/administrator-page/administrator-overview.component.ts
+++ b/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/administrator-page/administrator-overview.component.ts
@@ -12,7 +12,7 @@ import { AdministratorForm } from './administrator-form.model';
   template: `
     <app-overview-section title="PharmaNet Administrator"
                           [showEditRedirect]="showEditRedirect"
-                          [editRoute]="HealthAuthSiteRegRoutes.SITE_ADMINISTRATOR"
+                          [editRoute]="HealthAuthSiteRegRoutes.ADMINISTRATOR"
                           (route)="onRoute($event)">
       {{ pharmanetAdministrator | fullname }}
     </app-overview-section>

--- a/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/administrator-page/administrator-page.component.html
+++ b/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/administrator-page/administrator-page.component.html
@@ -11,7 +11,7 @@
     </app-page-subheader2>
 
     <app-options-form [form]="formState.form"
-                      fieldLabel="Administrator"
+                      fieldLabel="PharmaNet Administrator"
                       controlName="healthAuthorityPharmanetAdministratorId"
                       optionKey="id"
                       optionLabel="fullName"

--- a/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/administrator-page/administrator-page.component.spec.ts
+++ b/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/administrator-page/administrator-page.component.spec.ts
@@ -7,16 +7,13 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 
-import { MockSiteService } from 'test/mocks/mock-site.service';
-
 import { KeycloakService } from 'keycloak-angular';
 
 import { APP_CONFIG, APP_DI_CONFIG } from 'app/app-config.module';
 import { CapitalizePipe } from '@shared/pipes/capitalize.pipe';
-import { SiteService } from '@registration/shared/services/site.service';
 import { AdministratorPageComponent } from './administrator-page.component';
 
-describe('AdministratorComponent', () => {
+describe('AdministratorPageComponent', () => {
   let component: AdministratorPageComponent;
   let fixture: ComponentFixture<AdministratorPageComponent>;
 
@@ -38,10 +35,6 @@ describe('AdministratorComponent', () => {
         {
           provide: APP_CONFIG,
           useValue: APP_DI_CONFIG
-        },
-        {
-          provide: SiteService,
-          useClass: MockSiteService
         },
         CapitalizePipe
       ],

--- a/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/administrator-page/administrator-page.component.ts
+++ b/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/administrator-page/administrator-page.component.ts
@@ -94,11 +94,11 @@ export class AdministratorPageComponent extends AbstractEnrolmentPage implements
     const payload = this.formState.json;
     const { haid, sid } = this.route.snapshot.params;
 
-    return this.healthAuthorityResource.updateHealthAuthorityPharmanetAdministrator(haid, sid, payload)
+    return this.healthAuthorityResource.updateHealthAuthoritySitePharmanetAdministrator(haid, sid, payload)
       .pipe(exhaustMap(() => this.healthAuthorityResource.healthAuthoritySiteCompleted(haid, sid)));
   }
 
   protected afterSubmitIsSuccessful(): void {
-    this.routeUtils.routeRelativeTo(HealthAuthSiteRegRoutes.SITE_OVERVIEW);
+    this.routeUtils.routeRelativeTo(HealthAuthSiteRegRoutes.TECHNICAL_SUPPORT);
   }
 }

--- a/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/overview-page/overview-page.component.html
+++ b/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/overview-page/overview-page.component.html
@@ -18,6 +18,8 @@
   <app-remote-users-overview [remoteUsers]="healthAuthoritySite"></app-remote-users-overview>
   <app-administrator-overview [administrator]="healthAuthoritySite"
                               [pharmanetAdministrators]="pharmanetAdministrators"></app-administrator-overview>
+  <app-technical-support-overview [technicalSupport]="healthAuthoritySite"
+                                  [technicalSupports]="technicalSupports"></app-technical-support-overview>
 
   <ng-container *ngIf="!healthAuthoritySite?.submittedDate; else showBack">
     <div class="footer mb-4">

--- a/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/overview-page/overview-page.component.ts
+++ b/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/overview-page/overview-page.component.ts
@@ -26,6 +26,7 @@ import { HealthAuthSiteRegRoutes } from '@health-auth/health-auth-site-reg.route
 export class OverviewPageComponent implements OnInit {
   public busy: Subscription;
   public pharmanetAdministrators: Contact[];
+  public technicalSupports: Contact[];
   public healthAuthoritySite: HealthAuthoritySite;
   public showEditRedirect: boolean;
   public showSubmissionAction: boolean;
@@ -88,10 +89,11 @@ export class OverviewPageComponent implements OnInit {
     })
       .pipe(untilDestroyed(this))
       .subscribe(({
-                    healthAuthority: { pharmanetAdministrators },
+                    healthAuthority: { pharmanetAdministrators, technicalSupports },
                     healthAuthoritySite
                   }: { healthAuthority: HealthAuthority, healthAuthoritySite: HealthAuthoritySite }) => {
         this.pharmanetAdministrators = pharmanetAdministrators;
+        this.technicalSupports = technicalSupports;
         this.healthAuthoritySite = healthAuthoritySite;
       });
   }

--- a/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/remote-users-page/remote-users-page.component.ts
+++ b/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/remote-users-page/remote-users-page.component.ts
@@ -189,7 +189,7 @@ export class RemoteUsersPageComponent extends AbstractEnrolmentPage implements O
   protected afterSubmitIsSuccessful(): void {
     // TODO should account for updates which would redirect back to SiteManagement
     const nextRoutePath = (!this.isCompleted)
-      ? HealthAuthSiteRegRoutes.SITE_ADMINISTRATOR
+      ? HealthAuthSiteRegRoutes.ADMINISTRATOR
       : HealthAuthSiteRegRoutes.SITE_OVERVIEW;
 
     this.routeUtils.routeRelativeTo(['../', nextRoutePath]);

--- a/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/technical-support-page/technical-support-form-state.class.ts
+++ b/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/technical-support-page/technical-support-form-state.class.ts
@@ -1,0 +1,37 @@
+import { FormBuilder, FormControl, Validators } from '@angular/forms';
+
+import { AbstractFormState } from '@lib/classes/abstract-form-state.class';
+
+import { TechnicalSupportForm } from './technical-support-form.model';
+
+export class TechnicalSupportFormState extends AbstractFormState<TechnicalSupportForm> {
+  public constructor(
+    private fb: FormBuilder
+  ) {
+    super();
+
+    this.buildForm();
+  }
+
+  public get json(): TechnicalSupportForm {
+    if (!this.formInstance) {
+      return;
+    }
+
+    return this.formInstance.getRawValue();
+  }
+
+  public patchValue(model: TechnicalSupportForm): void {
+    if (!model) {
+      return;
+    }
+
+    this.formInstance.patchValue(model);
+  }
+
+  public buildForm(): void {
+    this.formInstance = this.fb.group({
+      healthAuthorityTechnicalSupportId: [null, [Validators.required]]
+    });
+  }
+}

--- a/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/technical-support-page/technical-support-form-state.class.ts
+++ b/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/technical-support-page/technical-support-form-state.class.ts
@@ -1,4 +1,4 @@
-import { FormBuilder, FormControl, Validators } from '@angular/forms';
+import { FormBuilder, Validators } from '@angular/forms';
 
 import { AbstractFormState } from '@lib/classes/abstract-form-state.class';
 

--- a/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/technical-support-page/technical-support-form.model.ts
+++ b/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/technical-support-page/technical-support-form.model.ts
@@ -1,0 +1,3 @@
+export interface TechnicalSupportForm {
+  healthAuthorityTechnicalSupportId: number;
+}

--- a/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/technical-support-page/technical-support-overview.component.spec.ts
+++ b/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/technical-support-page/technical-support-overview.component.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { TechnicalSupportOverviewComponent } from './technical-support-overview.component';
+import { FullnamePipe } from '@shared/pipes/fullname.pipe';
 
 describe('TechnicalSupportOverviewComponent', () => {
   let component: TechnicalSupportOverviewComponent;
@@ -8,9 +10,14 @@ describe('TechnicalSupportOverviewComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ TechnicalSupportOverviewComponent ]
-    })
-    .compileComponents();
+      imports: [
+        RouterTestingModule
+      ],
+      declarations: [
+        TechnicalSupportOverviewComponent,
+        FullnamePipe
+      ]
+    }).compileComponents();
   });
 
   beforeEach(() => {

--- a/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/technical-support-page/technical-support-overview.component.spec.ts
+++ b/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/technical-support-page/technical-support-overview.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TechnicalSupportOverviewComponent } from './technical-support-overview.component';
+
+describe('TechnicalSupportOverviewComponent', () => {
+  let component: TechnicalSupportOverviewComponent;
+  let fixture: ComponentFixture<TechnicalSupportOverviewComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ TechnicalSupportOverviewComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TechnicalSupportOverviewComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/technical-support-page/technical-support-overview.component.ts
+++ b/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/technical-support-page/technical-support-overview.component.ts
@@ -1,16 +1,41 @@
-import { Component, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+
+import { Contact } from '@lib/models/contact.model';
+import { AbstractOverview } from '@lib/classes/abstract-overview.class';
+import { HealthAuthSiteRegRoutes } from '@health-auth/health-auth-site-reg.routes';
+
+import { TechnicalSupportForm } from '@health-auth/pages/technical-support-page/technical-support-form.model';
 
 @Component({
   selector: 'app-technical-support-overview',
   template: `
-    <p>
-      technical-support-overview works!
-    </p>
+    <app-overview-section title="Technical Support"
+                          [showEditRedirect]="showEditRedirect"
+                          [editRoute]="HealthAuthSiteRegRoutes.TECHNICAL_SUPPORT"
+                          (route)="onRoute($event)">
+      {{ technicalSupportContact | fullname }}
+    </app-overview-section>
   `,
-  styles: []
+  styles: [],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class TechnicalSupportOverviewComponent implements OnInit {
-  constructor() { }
+export class TechnicalSupportOverviewComponent extends AbstractOverview implements OnInit {
+  @Input() technicalSupport: TechnicalSupportForm;
+  @Input() technicalSupports: Contact[];
+  public HealthAuthSiteRegRoutes = HealthAuthSiteRegRoutes;
+
+  constructor(
+    route: ActivatedRoute,
+    router: Router
+  ) {
+    super(route, router, HealthAuthSiteRegRoutes.MODULE_PATH);
+  }
+
+  public get technicalSupportContact(): Contact {
+    return this.technicalSupports
+      ?.find(pa => pa.id === this.technicalSupport.healthAuthorityTechnicalSupportId) ?? null;
+  }
 
   public ngOnInit(): void { }
 }

--- a/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/technical-support-page/technical-support-overview.component.ts
+++ b/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/technical-support-page/technical-support-overview.component.ts
@@ -1,0 +1,16 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-technical-support-overview',
+  template: `
+    <p>
+      technical-support-overview works!
+    </p>
+  `,
+  styles: []
+})
+export class TechnicalSupportOverviewComponent implements OnInit {
+  constructor() { }
+
+  public ngOnInit(): void { }
+}

--- a/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/technical-support-page/technical-support-page.component.html
+++ b/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/technical-support-page/technical-support-page.component.html
@@ -11,7 +11,7 @@
     </app-page-subheader2>
 
     <app-options-form [form]="formState.form"
-                      fieldLabel="Administrator"
+                      fieldLabel="Technical Support"
                       controlName="healthAuthorityTechnicalSupportId"
                       optionKey="id"
                       optionLabel="fullName"

--- a/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/technical-support-page/technical-support-page.component.html
+++ b/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/technical-support-page/technical-support-page.component.html
@@ -1,1 +1,27 @@
-<p>technical-support-page works!</p>
+<app-page [busy]="busy">
+  <app-page-header>PharmaNet Site Registration</app-page-header>
+  <app-site-progress-indicator [inProgress]="!isCompleted"></app-site-progress-indicator>
+
+  <app-page-section>
+    <app-page-subheader2>
+      <ng-container appPageSubheader2Title>Technical Support</ng-container>
+      <ng-container appPageSubheader2Summary>
+        Choose the Technical Support for this Health Authority.
+      </ng-container>
+    </app-page-subheader2>
+
+    <app-options-form [form]="formState.form"
+                      fieldLabel="Administrator"
+                      controlName="healthAuthorityTechnicalSupportId"
+                      optionKey="id"
+                      optionLabel="fullName"
+                      [availableOptions]="technicalSupports"></app-options-form>
+  </app-page-section>
+
+  <app-page-footer [isInitialEnrolment]="!isCompleted"
+                   [hasSecondaryAction]="true"
+                   primaryActionLabel="Save and Continue"
+                   (save)="onSubmit()"
+                   (back)="onBack()"
+                   (continue)="onBack()"></app-page-footer>
+</app-page>

--- a/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/technical-support-page/technical-support-page.component.html
+++ b/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/technical-support-page/technical-support-page.component.html
@@ -1,0 +1,1 @@
+<p>technical-support-page works!</p>

--- a/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/technical-support-page/technical-support-page.component.spec.ts
+++ b/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/technical-support-page/technical-support-page.component.spec.ts
@@ -10,8 +10,8 @@ import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { KeycloakService } from 'keycloak-angular';
 
 import { APP_CONFIG, APP_DI_CONFIG } from 'app/app-config.module';
-import { TechnicalSupportPageComponent } from './technical-support-page.component';
 import { CapitalizePipe } from '@shared/pipes/capitalize.pipe';
+import { TechnicalSupportPageComponent } from './technical-support-page.component';
 
 describe('TechnicalSupportPageComponent', () => {
   let component: TechnicalSupportPageComponent;

--- a/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/technical-support-page/technical-support-page.component.spec.ts
+++ b/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/technical-support-page/technical-support-page.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TechnicalSupportPageComponent } from './technical-support-page.component';
+
+describe('TechnicalSupportPageComponent', () => {
+  let component: TechnicalSupportPageComponent;
+  let fixture: ComponentFixture<TechnicalSupportPageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ TechnicalSupportPageComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TechnicalSupportPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/technical-support-page/technical-support-page.component.spec.ts
+++ b/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/technical-support-page/technical-support-page.component.spec.ts
@@ -1,6 +1,17 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 
+import { KeycloakService } from 'keycloak-angular';
+
+import { APP_CONFIG, APP_DI_CONFIG } from 'app/app-config.module';
 import { TechnicalSupportPageComponent } from './technical-support-page.component';
+import { CapitalizePipe } from '@shared/pipes/capitalize.pipe';
 
 describe('TechnicalSupportPageComponent', () => {
   let component: TechnicalSupportPageComponent;
@@ -8,9 +19,27 @@ describe('TechnicalSupportPageComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ TechnicalSupportPageComponent ]
-    })
-    .compileComponents();
+      declarations: [
+        TechnicalSupportPageComponent
+      ],
+      imports: [
+        BrowserAnimationsModule,
+        HttpClientTestingModule,
+        RouterTestingModule,
+        ReactiveFormsModule,
+        MatDialogModule,
+        MatSnackBarModule
+      ],
+      providers: [
+        KeycloakService,
+        {
+          provide: APP_CONFIG,
+          useValue: APP_DI_CONFIG
+        },
+        CapitalizePipe
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
   });
 
   beforeEach(() => {

--- a/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/technical-support-page/technical-support-page.component.ts
+++ b/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/technical-support-page/technical-support-page.component.ts
@@ -1,0 +1,90 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { MatDialog } from '@angular/material/dialog';
+
+import { BehaviorSubject, EMPTY } from 'rxjs';
+import { exhaustMap, tap } from 'rxjs/operators';
+
+import { AbstractEnrolmentPage } from '@lib/classes/abstract-enrolment-page.class';
+import { Contact } from '@lib/models/contact.model';
+import { RouteUtils } from '@lib/utils/route-utils.class';
+import { FormUtilsService } from '@core/services/form-utils.service';
+import { HealthAuthorityResource } from '@core/resources/health-authority-resource.service';
+import { HealthAuthority } from '@shared/models/health-authority.model';
+import { HealthAuthSiteRegRoutes } from '@health-auth/health-auth-site-reg.routes';
+import { TechnicalSupportFormState } from '@health-auth/pages/technical-support-page/technical-support-form-state.class';
+import { HealthAuthoritySite } from '@health-auth/shared/models/health-authority-site.model';
+
+@Component({
+  selector: 'app-technical-support-page',
+  templateUrl: './technical-support-page.component.html',
+  styleUrls: ['./technical-support-page.component.scss']
+})
+export class TechnicalSupportPageComponent extends AbstractEnrolmentPage implements OnInit {
+  public formState: TechnicalSupportFormState;
+  public title: string;
+  public routeUtils: RouteUtils;
+  public isCompleted: boolean;
+  public technicalSupports: BehaviorSubject<{ id: number, fullName: string }[]>;
+
+  constructor(
+    protected dialog: MatDialog,
+    protected formUtilsService: FormUtilsService,
+    private fb: FormBuilder,
+    private healthAuthorityResource: HealthAuthorityResource,
+    private route: ActivatedRoute,
+    router: Router
+  ) {
+    super(dialog, formUtilsService);
+
+    this.title = route.snapshot.data.title;
+    this.routeUtils = new RouteUtils(route, router, HealthAuthSiteRegRoutes.MODULE_PATH);
+    // TODO revisit passed subject value type
+    this.technicalSupports = new BehaviorSubject<{ id: number, fullName: string }[]>([]);
+  }
+
+  public onBack(): void {
+    const backRoutePath = (this.isCompleted)
+      ? HealthAuthSiteRegRoutes.SITE_OVERVIEW
+      : HealthAuthSiteRegRoutes.REMOTE_USERS;
+
+    this.routeUtils.routeRelativeTo(backRoutePath);
+  }
+
+  public ngOnInit(): void {
+    this.createFormInstance();
+    this.patchForm();
+    this.initForm();
+  }
+
+  protected createFormInstance(): void {
+    this.formState = new TechnicalSupportFormState(this.fb);
+  }
+
+  protected patchForm(): void {
+    const healthAuthId = +this.route.snapshot.params.haid;
+    const healthAuthSiteId = +this.route.snapshot.params.sid;
+    if (!healthAuthId || !healthAuthSiteId) {
+      return;
+    }
+
+    this.busy = this.healthAuthorityResource.getHealthAuthorityById(healthAuthId)
+      .pipe(
+        tap(({ pharmanetAdministrators }: HealthAuthority) => {
+          const administrators = pharmanetAdministrators
+            .map(({ id, firstName, lastName }: Contact) => ({ id, fullName: `${firstName} ${lastName}` }));
+          this.technicalSupports.next(administrators);
+        }),
+        exhaustMap((_: HealthAuthority) =>
+          (healthAuthSiteId)
+            ? this.healthAuthorityResource.getHealthAuthoritySiteById(healthAuthId, healthAuthSiteId)
+            : EMPTY
+        )
+      )
+      .subscribe(({ healthAuthorityTechnicalSupportId, completed }: HealthAuthoritySite) => {
+        this.isCompleted = completed;
+        this.formState.patchValue({ healthAuthorityTechnicalSupportId });
+      });
+  }
+}

--- a/prime-angular-frontend/src/app/modules/health-auth-site-reg/shared/models/health-authority-site.model.ts
+++ b/prime-angular-frontend/src/app/modules/health-auth-site-reg/shared/models/health-authority-site.model.ts
@@ -22,6 +22,8 @@ export interface HealthAuthoritySite {
   remoteUsers: RemoteUser[];
   healthAuthorityPharmanetAdministratorId: number;
   healthAuthorityPharmanetAdministrator: Contact;
+  healthAuthorityTechnicalSupportId: number;
+  healthAuthorityTechnicalSupport: Contact;
   // Indicates that a user has progressed through the entire registration, and
   // reached the overview page switching them from wizard to spoking navigation
   completed: boolean;

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/administrator-page/administrator-page.component.html
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/administrator-page/administrator-page.component.html
@@ -6,7 +6,8 @@
         novalidate
         autocomplete="off">
     <app-contact-profile-form [title]="title"
-                              [form]="formState.form">
+                              [form]="formState.form"
+                              [hasAddressToggle]="true">
       <app-same-as selectFor="administratorPharmaNet"
                    (selected)="onSelect($event)"></app-same-as>
 

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/administrator-page/administrator-page.component.spec.ts
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/administrator-page/administrator-page.component.spec.ts
@@ -14,7 +14,7 @@ import { APP_CONFIG, APP_DI_CONFIG } from 'app/app-config.module';
 import { SiteService } from '@registration/shared/services/site.service';
 import { AdministratorPageComponent } from './administrator-page.component';
 
-describe('AdministratorComponent', () => {
+describe('AdministratorPageComponent', () => {
   let component: AdministratorPageComponent;
   let fixture: ComponentFixture<AdministratorPageComponent>;
 

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/privacy-officer-page/privacy-officer-page.component.html
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/privacy-officer-page/privacy-officer-page.component.html
@@ -6,7 +6,8 @@
         novalidate
         autocomplete="off">
     <app-contact-profile-form [title]="title"
-                              [form]="formState.form">
+                              [form]="formState.form"
+                              [hasAddressToggle]="true">
       <app-same-as selectFor="privacyOfficer"
                    (selected)="onSelect($event)"></app-same-as>
 

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/technical-support-page/technical-support-page.component.html
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/technical-support-page/technical-support-page.component.html
@@ -6,7 +6,8 @@
         novalidate
         autocomplete="off">
     <app-contact-profile-form [title]="title"
-                              [form]="formState.form">
+                              [form]="formState.form"
+                              [hasAddressToggle]="true">
       <app-same-as selectFor="technicalSupport"
                    (selected)="onSelect($event)"></app-same-as>
 

--- a/prime-angular-frontend/src/app/shared/components/site/contact-profile-form/contact-profile-form.component.html
+++ b/prime-angular-frontend/src/app/shared/components/site/contact-profile-form/contact-profile-form.component.html
@@ -112,30 +112,27 @@
     </div>
   </app-page-section>
 
-  <ng-container *ngIf="hasAddressToggle; else noToggle">
-    <ng-container *ngTemplateOutlet="toggle"></ng-container>
-  </ng-container>
+  <!-- Must bind to hidden instead of using *ngIf so toggle can be located by ViewChild -->
+  <div [hidden]="!hasAddressToggle">
+    <div class="mb-4">
+      <mat-slide-toggle #slider
+                        color="primary"
+                        (change)="onAddressChange($event)">
+        The {{ title }}'s mailing address is the same as the site’s address
+      </mat-slide-toggle>
+    </div>
 
-  <ng-template #noToggle>
+    <ng-container *ngIf="!slider.checked">
+      <ng-container *ngTemplateOutlet="address"></ng-container>
+    </ng-container>
+  </div>
+
+  <ng-container *ngIf="!hasAddressToggle">
     <ng-container *ngTemplateOutlet="address"></ng-container>
-  </ng-template>
+  </ng-container>
 
   <ng-content select="app-page-footer"></ng-content>
 </ng-container>
-
-<ng-template #toggle>
-  <div class="mb-4">
-    <mat-slide-toggle #slider
-                      color="primary"
-                      (change)="onAddressChange($event)">
-      The {{ title }}'s mailing address is the same as the site’s address
-    </mat-slide-toggle>
-  </div>
-
-  <ng-container *ngIf="!slider.checked">
-    <ng-container *ngTemplateOutlet="address"></ng-container>
-  </ng-container>
-</ng-template>
 
 <ng-template #address>
   <app-page-section *ngIf="!excludeList.includes('physicalAddress')">

--- a/prime-angular-frontend/src/app/shared/components/site/contact-profile-form/contact-profile-form.component.html
+++ b/prime-angular-frontend/src/app/shared/components/site/contact-profile-form/contact-profile-form.component.html
@@ -112,36 +112,38 @@
     </div>
   </app-page-section>
 
-  <!-- Must be hidden and not ngIf so that the toggle can be located by ViewChild -->
-  <div [hidden]="!hasAddressToggle && excludeList.includes('physicalAddress')">
-    <div class="mb-4">
-      <mat-slide-toggle #slider
-                        color="primary"
-                        (change)="onAddressChange($event)">
-        The {{ title }}'s mailing address is the same as the site’s address
-      </mat-slide-toggle>
-    </div>
+  <ng-container *ngIf="hasAddressToggle; else noToggle">
+    <ng-container *ngTemplateOutlet="toggle"></ng-container>
+  </ng-container>
 
-    <ng-container *ngIf="!slider.checked">
-      <ng-container *ngTemplateOutlet="address"></ng-container>
-    </ng-container>
-  </div>
-
-  <div [hidden]="hasAddressToggle">
+  <ng-template #noToggle>
     <ng-container *ngTemplateOutlet="address"></ng-container>
-  </div>
+  </ng-template>
 
   <ng-content select="app-page-footer"></ng-content>
 </ng-container>
 
+<ng-template #toggle>
+  <div class="mb-4">
+    <mat-slide-toggle #slider
+                      color="primary"
+                      (change)="onAddressChange($event)">
+      The {{ title }}'s mailing address is the same as the site’s address
+    </mat-slide-toggle>
+  </div>
+
+  <ng-container *ngIf="!slider.checked">
+    <ng-container *ngTemplateOutlet="address"></ng-container>
+  </ng-container>
+</ng-template>
+
 <ng-template #address>
-  <app-page-section>
+  <app-page-section *ngIf="!excludeList.includes('physicalAddress')">
     <app-page-subheader2>
       <ng-container appPageSubheader2Title>Address</ng-container>
     </app-page-subheader2>
 
-    <app-address-form *ngIf="!excludeList.includes('physicalAddress')"
-                      [form]="physicalAddress"
+    <app-address-form [form]="physicalAddress"
                       [showManualButton]="true"
                       [showAddressFields]="showAddressFields"></app-address-form>
   </app-page-section>

--- a/prime-angular-frontend/src/app/shared/components/site/contact-profile-form/contact-profile-form.component.ts
+++ b/prime-angular-frontend/src/app/shared/components/site/contact-profile-form/contact-profile-form.component.ts
@@ -82,7 +82,6 @@ export class ContactProfileFormComponent implements OnInit, AfterContentInit {
   constructor(
     private formUtilsService: FormUtilsService
   ) {
-    this.hasAddressToggle = true;
     this.excludeList = [];
   }
 

--- a/prime-angular-frontend/src/app/shared/components/site/contact-profile-form/contact-profile-form.component.ts
+++ b/prime-angular-frontend/src/app/shared/components/site/contact-profile-form/contact-profile-form.component.ts
@@ -18,6 +18,7 @@ import { Address } from '@shared/models/address.model';
 import { Contact } from '@lib/models/contact.model';
 import { PageFooterComponent } from '@shared/components/pages/page-footer/page-footer.component';
 
+// TODO switch from this.toggle to this.hasAddressToggle and exclude list check
 @Component({
   selector: 'app-contact-profile-form',
   templateUrl: './contact-profile-form.component.html',
@@ -114,7 +115,11 @@ export class ContactProfileFormComponent implements OnInit, AfterContentInit {
    * Event handler for the address toggle.
    */
   public onAddressChange({ checked }: MatSlideToggleChange) {
-    if (!checked) {
+    if(!this.hasAddressToggle || this.excludeList.includes('physicalAddress')) {
+      return;
+    }
+
+    if (checked) {
       this.physicalAddress.reset();
     }
 
@@ -148,7 +153,7 @@ export class ContactProfileFormComponent implements OnInit, AfterContentInit {
           if (Address.isNotEmpty(contact.physicalAddress)) {
             // Change the validators based on the toggled value, otherwise
             // the default is required so the address should be displayed
-            this.toggleAddress(true);
+            this.toggleAddress();
             this.expandAddressFields();
           }
         });

--- a/prime-angular-frontend/src/app/shared/components/site/contact-profile-form/contact-profile-form.component.ts
+++ b/prime-angular-frontend/src/app/shared/components/site/contact-profile-form/contact-profile-form.component.ts
@@ -18,7 +18,6 @@ import { Address } from '@shared/models/address.model';
 import { Contact } from '@lib/models/contact.model';
 import { PageFooterComponent } from '@shared/components/pages/page-footer/page-footer.component';
 
-// TODO switch from this.toggle to this.hasAddressToggle and exclude list check
 @Component({
   selector: 'app-contact-profile-form',
   templateUrl: './contact-profile-form.component.html',

--- a/prime-dotnet-webapi/Controllers/HealthAuthoritySitesController.cs
+++ b/prime-dotnet-webapi/Controllers/HealthAuthoritySitesController.cs
@@ -253,6 +253,30 @@ namespace Prime.Controllers
             return NoContent();
         }
 
+        // PUT: api/health-authorities/5/sites/5/technical-support
+        /// <summary>
+        /// Updates a specific health authority site's technical support.
+        /// </summary>
+        /// <param name="healthAuthorityId"></param>
+        /// <param name="siteId"></param>
+        /// <param name="payload"></param>
+        [HttpPut("{siteId}/administrator", Name = nameof(UpdateTechnicalSupport))]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ApiMessageResponse), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        public async Task<ActionResult> UpdateTechnicalSupport(int healthAuthorityId, int siteId, HealthAuthoritySiteTechnicalSupportViewModel payload)
+        {
+            if (!await _healthAuthoritySiteService.SiteExistsAsync(healthAuthorityId, siteId))
+            {
+                return NotFound($"Health authority site not found with id {siteId}");
+            }
+
+            await _healthAuthoritySiteService.UpdateTechnicalSupportAsync(siteId, payload.HealthAuthorityTechnicalSupportId);
+
+            return NoContent();
+        }
+
         // PUT: api/health-authorities/5/sites/5/finalize/site-completed
         /// <summary>
         /// Sets the health authority site as "completed", allowing frontend and backend behavioural changes.

--- a/prime-dotnet-webapi/Controllers/HealthAuthoritySitesController.cs
+++ b/prime-dotnet-webapi/Controllers/HealthAuthoritySitesController.cs
@@ -260,7 +260,7 @@ namespace Prime.Controllers
         /// <param name="healthAuthorityId"></param>
         /// <param name="siteId"></param>
         /// <param name="payload"></param>
-        [HttpPut("{siteId}/administrator", Name = nameof(UpdateTechnicalSupport))]
+        [HttpPut("{siteId}/technical-support", Name = nameof(UpdateTechnicalSupport))]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(typeof(ApiMessageResponse), StatusCodes.Status404NotFound)]

--- a/prime-dotnet-webapi/Migrations/20210916182739_AddHealthAuthSiteTechSupportContact.Designer.cs
+++ b/prime-dotnet-webapi/Migrations/20210916182739_AddHealthAuthSiteTechSupportContact.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Prime;
@@ -10,9 +11,10 @@ using Prime.Models;
 namespace Prime.Migrations
 {
     [DbContext(typeof(ApiDbContext))]
-    partial class ApiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210916182739_AddHealthAuthSiteTechSupportContact")]
+    partial class AddHealthAuthSiteTechSupportContact
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/prime-dotnet-webapi/Migrations/20210916182739_AddHealthAuthSiteTechSupportContact.cs
+++ b/prime-dotnet-webapi/Migrations/20210916182739_AddHealthAuthSiteTechSupportContact.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Prime.Migrations
+{
+    public partial class AddHealthAuthSiteTechSupportContact : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "HealthAuthorityTechnicalSupportId",
+                table: "HealthAuthoritySite",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_HealthAuthoritySite_HealthAuthorityTechnicalSupportId",
+                table: "HealthAuthoritySite",
+                column: "HealthAuthorityTechnicalSupportId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_HealthAuthoritySite_HealthAuthorityContact_HealthAuthorityT~",
+                table: "HealthAuthoritySite",
+                column: "HealthAuthorityTechnicalSupportId",
+                principalTable: "HealthAuthorityContact",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_HealthAuthoritySite_HealthAuthorityContact_HealthAuthorityT~",
+                table: "HealthAuthoritySite");
+
+            migrationBuilder.DropIndex(
+                name: "IX_HealthAuthoritySite_HealthAuthorityTechnicalSupportId",
+                table: "HealthAuthoritySite");
+
+            migrationBuilder.DropColumn(
+                name: "HealthAuthorityTechnicalSupportId",
+                table: "HealthAuthoritySite");
+        }
+    }
+}

--- a/prime-dotnet-webapi/Models/Health Authorities/HealthAuthoritySite.cs
+++ b/prime-dotnet-webapi/Models/Health Authorities/HealthAuthoritySite.cs
@@ -36,7 +36,7 @@ namespace Prime.Models.HealthAuthorities
 
         // TODO list of care types?
         // public int? HealthAuthorityCareTypeId { get; set; }
-        //
+
         // [JsonIgnore]
         // public HealthAuthorityCareType HealthAuthorityCareType { get; set; }
 
@@ -50,6 +50,10 @@ namespace Prime.Models.HealthAuthorities
 
         [JsonIgnore]
         public HealthAuthorityPharmanetAdministrator HealthAuthorityPharmanetAdministrator { get; set; }
+
+        public int? HealthAuthorityTechnicalSupportId { get; set; }
+
+        public HealthAuthorityTechnicalSupport HealthAuthorityTechnicalSupport { get; set; }
 
         public bool Completed { get; set; }
 

--- a/prime-dotnet-webapi/Services/HealthAuthorityService.cs
+++ b/prime-dotnet-webapi/Services/HealthAuthorityService.cs
@@ -100,10 +100,14 @@ namespace Prime.Services
 
             _context.Addresses.RemoveRange(oldContacts.Select(c => c.PhysicalAddress).Where(a => a != null));
 
-            var newContacts = contacts.Select(contact => new T
+            var newContacts = contacts.Select(contact =>
             {
-                HealthAuthorityOrganizationId = healthAuthorityId,
-                Contact = _mapper.Map<Contact>(contact)
+                contact.Id = 0;
+                return new T
+                {
+                    HealthAuthorityOrganizationId = healthAuthorityId,
+                    Contact = _mapper.Map<Contact>(contact)
+                };
             });
 
             _context.HealthAuthorityContacts.AddRange(newContacts);

--- a/prime-dotnet-webapi/Services/HealthAuthoritySiteService.cs
+++ b/prime-dotnet-webapi/Services/HealthAuthoritySiteService.cs
@@ -134,7 +134,6 @@ namespace Prime.Services
             await _context.SaveChangesAsync();
         }
 
-
         public async Task UpdatePharmanetAdministratorAsync(int siteId, int contactId)
         {
             var site = await _context.HealthAuthoritySites
@@ -147,6 +146,22 @@ namespace Prime.Services
 
             // TODO check administrator exists on the HealthAuthority list of administrator(s)
             site.HealthAuthorityPharmanetAdministratorId = healthAuthorityPharmanetAdministratorId;
+
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task UpdateTechnicalSupportAsync(int siteId, int contactId)
+        {
+            var site = await _context.HealthAuthoritySites
+                .SingleOrDefaultAsync(has => has.Id == siteId);
+
+            var healthAuthorityTechnicalSupportId = await _context.HealthAuthorityContacts
+                .Where(hac => hac.ContactId == contactId)
+                .Select(hac => hac.Id)
+                .SingleOrDefaultAsync();
+
+            // TODO check technical support exists on the HealthAuthority list of technical support(s)
+            site.HealthAuthorityTechnicalSupportId = healthAuthorityTechnicalSupportId;
 
             await _context.SaveChangesAsync();
         }

--- a/prime-dotnet-webapi/Services/HealthAuthoritySiteService.cs
+++ b/prime-dotnet-webapi/Services/HealthAuthoritySiteService.cs
@@ -134,34 +134,24 @@ namespace Prime.Services
             await _context.SaveChangesAsync();
         }
 
-        public async Task UpdatePharmanetAdministratorAsync(int siteId, int contactId)
+        public async Task UpdatePharmanetAdministratorAsync(int siteId, int healthAuthorityContactId)
         {
             var site = await _context.HealthAuthoritySites
                 .SingleOrDefaultAsync(has => has.Id == siteId);
 
-            var healthAuthorityPharmanetAdministratorId = await _context.HealthAuthorityContacts
-                .Where(hac => hac.ContactId == contactId)
-                .Select(hac => hac.Id)
-                .SingleOrDefaultAsync();
-
             // TODO check administrator exists on the HealthAuthority list of administrator(s)
-            site.HealthAuthorityPharmanetAdministratorId = healthAuthorityPharmanetAdministratorId;
+            site.HealthAuthorityPharmanetAdministratorId = healthAuthorityContactId;
 
             await _context.SaveChangesAsync();
         }
 
-        public async Task UpdateTechnicalSupportAsync(int siteId, int contactId)
+        public async Task UpdateTechnicalSupportAsync(int siteId, int healthAuthorityContactId)
         {
             var site = await _context.HealthAuthoritySites
                 .SingleOrDefaultAsync(has => has.Id == siteId);
 
-            var healthAuthorityTechnicalSupportId = await _context.HealthAuthorityContacts
-                .Where(hac => hac.ContactId == contactId)
-                .Select(hac => hac.Id)
-                .SingleOrDefaultAsync();
-
             // TODO check technical support exists on the HealthAuthority list of technical support(s)
-            site.HealthAuthorityTechnicalSupportId = healthAuthorityTechnicalSupportId;
+            site.HealthAuthorityTechnicalSupportId = healthAuthorityContactId;
 
             await _context.SaveChangesAsync();
         }

--- a/prime-dotnet-webapi/Services/interfaces/IHealthAuthoritySiteService.cs
+++ b/prime-dotnet-webapi/Services/interfaces/IHealthAuthoritySiteService.cs
@@ -25,7 +25,7 @@ namespace Prime.Services
         Task UpdateHoursOperationAsync(int siteId, ICollection<BusinessDay> businessHours);
         Task UpdateRemoteUsersAsync(int siteId, ICollection<RemoteUser> remoteUsers);
         Task UpdatePharmanetAdministratorAsync(int siteId, int healthAuthoritySiteAdministratorId);
-
+        Task UpdateTechnicalSupportAsync(int siteId, int technicalSupportId);
         Task SetSiteCompletedAsync(int siteId);
         Task SiteSubmissionAsync(int siteId);
     }

--- a/prime-dotnet-webapi/ViewModels/Health Authority Sites/HealthAuthoritySiteTechnicalSupportViewModel.cs
+++ b/prime-dotnet-webapi/ViewModels/Health Authority Sites/HealthAuthoritySiteTechnicalSupportViewModel.cs
@@ -1,0 +1,19 @@
+using System;
+using FluentValidation;
+using Prime.Models.HealthAuthorities;
+
+namespace Prime.ViewModels.HealthAuthoritySites
+{
+    public class HealthAuthoritySiteTechnicalSupportViewModel
+    {
+        public int HealthAuthorityTechnicalSupportId { get; set; }
+    }
+
+    public class HealthAuthoritySiteTechnicalSupportValidator : AbstractValidator<HealthAuthoritySiteTechnicalSupportViewModel>
+    {
+        public HealthAuthoritySiteTechnicalSupportValidator()
+        {
+            RuleFor(x => x.HealthAuthorityTechnicalSupportId).NotNull();
+        }
+    }
+}

--- a/prime-dotnet-webapi/ViewModels/Health Authority Sites/HealthAuthoritySiteViewModel.cs
+++ b/prime-dotnet-webapi/ViewModels/Health Authority Sites/HealthAuthoritySiteViewModel.cs
@@ -22,8 +22,9 @@ namespace Prime.ViewModels.HealthAuthoritySites
         public ICollection<BusinessDay> BusinessHours { get; set; }
         public ICollection<RemoteUser> RemoteUsers { get; set; }
         public int? HealthAuthorityPharmanetAdministratorId { get; set; }
-        // TODO don't need the whole thing: first and last name for overview
         public HealthAuthorityPharmanetAdministrator HealthAuthorityPharmanetAdministrator { get; set; }
+        public int? HealthAuthorityTechnicalSupportId { get; set; }
+        public HealthAuthorityTechnicalSupport HealthAuthorityTechnicalSupport { get; set; }
         public bool Completed { get; set; }
         public DateTimeOffset? SubmittedDate { get; set; }
         public DateTimeOffset? ApprovedDate { get; set; }


### PR DESCRIPTION
* Adds missing technical support page to Health Auth site registration
* Fixes contact update issue in Health Auth admin
* Fixes contact profile form for Health Auth admin and Site Registration

**Testing Steps:**

When testing you will want to add/update a Health Authority Organization Information and play with the contact(s) and then create a health authority site registration and select an admin and technical support contact.  Finally, test contacts is also work in site registration by creating a community pharmacy or practice site and adding all three types of contacts in every way imagineable.