### PR TITLE
PRIME-1860 site reg - edit icons appear in admin screens

### DIFF
--- a/prime-angular-frontend/src/app/shared/components/site/overview-container/overview-container.component.html
+++ b/prime-angular-frontend/src/app/shared/components/site/overview-container/overview-container.component.html
@@ -55,7 +55,7 @@
 <ng-container *ngIf="site">
 
   <app-overview-section title="Care Setting"
-                        [showEditRedirect]="!site.submittedDate"
+                        [showEditRedirect]="!site.submittedDate && !admin"
                         [editRoute]="SiteRoutes.CARE_SETTING"
                         (route)="onRouteRelative($event)">
     <app-enrollee-property title="Care Setting">
@@ -68,7 +68,7 @@
   </app-overview-section>
 
   <app-overview-section title="Site Business Licence"
-                        [showEditRedirect]="!site.submittedDate || !site.businessLicence?.completed"
+                        [showEditRedirect]="(!site.submittedDate || !site.businessLicence?.completed) && !admin"
                         [editRoute]="SiteRoutes.BUSINESS_LICENCE"
                         (route)="onRouteRelative($event)">
 
@@ -88,8 +88,8 @@
       {{ site?.pec | default }}
     </app-enrollee-property>
 
-    <app-enrollee-property title="Deferred Business Licence Reason"
-                           *ngIf="site.businessLicence?.deferredLicenceReason">
+    <app-enrollee-property *ngIf="site.businessLicence?.deferredLicenceReason"
+                           title="Deferred Business Licence Reason">
       {{ site.businessLicence.deferredLicenceReason | default }}
     </app-enrollee-property>
 


### PR DESCRIPTION
Hides 2 redirect icons in site reg overview admin and [PRIME-1826 Site Registration Allow Editing of All Pages](https://github.com/bcgov/moh-prime/pull/1616) handles addresses