### PR TITLE
[hotfix] use correct image tag

### DIFF
--- a/infrastructure/prime-app-ephemeral-template.yml
+++ b/infrastructure/prime-app-ephemeral-template.yml
@@ -700,6 +700,7 @@ objects:
           automatic: true
           containerNames:
             - ${SVC_NAME}-webapi
+            - run-migrations
           from:
             kind: ImageStreamTag
             namespace: "${OC_NAMESPACE}-tools"
@@ -967,6 +968,7 @@ objects:
           automatic: true
           containerNames:
             - ${SVC_NAME}-document-manager
+            - run-migrations
           from:
             kind: ImageStreamTag
             namespace: "${OC_NAMESPACE}-tools"

--- a/infrastructure/prime-app-template.yml
+++ b/infrastructure/prime-app-template.yml
@@ -703,6 +703,7 @@ objects:
           automatic: true
           containerNames:
             - ${SVC_NAME}-${API_POD}
+            - run-migrations
           from:
             kind: ImageStreamTag
             namespace: "${OC_NAMESPACE}-tools"
@@ -947,6 +948,7 @@ objects:
           automatic: true
           containerNames:
             - ${SVC_NAME}-${DOCMAN_POD}
+            - run-migrations
           from:
             kind: ImageStreamTag
             namespace: "${OC_NAMESPACE}-tools"


### PR DESCRIPTION
- let imagechange trigger in deployment config automatically update correct image tag for init containers
fixes initcontainers not running latest migrations