### PR TITLE
PRIME-1899 Provisioner Access Shows Error Dialog

### DIFF
--- a/prime-angular-frontend/src/app/core/services/error-handler.service.ts
+++ b/prime-angular-frontend/src/app/core/services/error-handler.service.ts
@@ -41,7 +41,16 @@ export class ErrorHandlerService implements ErrorHandler {
     } else {
       // Client error has occurred (Angular Error, ReferenceError...)
       webApiLogger.error(message, { url })
-        .subscribe(logId => dialogLogger.log(logId));
+        .subscribe(logId => {
+          // Temporary fix to stop the dialog from showing in /provisioner-access
+          // where users are not authenticated
+          // TODO investigate keycloak initialization for specific modules only using CanLoad
+          if(message.includes('user profile was not loaded')) {
+            return;
+          }
+
+          dialogLogger.log(logId);
+        });
     }
 
     logger.error(message, { url });


### PR DESCRIPTION
Temporary patch to stop the error dialog on provisioner access due to the keycloak user profile not being loaded on a unauthenticated view