### PR TITLE
PRIME-1935 - Fix Local Docman

### DIFF
--- a/document-manager/backend/.env-local
+++ b/document-manager/backend/.env-local
@@ -1,3 +1,4 @@
+DB_HOST=postgres
 SQLALCHEMY_DATABASE_URI=postgres://postgres:postgres@postgres:5432/postgres
 
 # Used for building Location header redirects back to ourselves


### PR DESCRIPTION
Document manager and Document Manager Migrate does not work locally. Now it does.