### PR TITLE
Update Local Secrets Documentation

### DIFF
--- a/prime-dotnet-webapi/README.md
+++ b/prime-dotnet-webapi/README.md
@@ -27,8 +27,9 @@ After acquiring the secrets.json file from the appropriate source, open a termin
 `type .\secrets.json | dotnet user-secrets set` on Windows or
 `cat ./secrets.json | dotnet user-secrets set` on macOS / Linux
 to set the secrets for local development.
-On Windows, they are stored at `%APPDATA%\Microsoft\UserSecrets\<user_secrets_id>\secrets.json`. On macOS / Linux, they are stored at `~/.microsoft/usersecrets/<user_secrets_id>/secrets.json`.
+After running the command, the original secrets.json file is no longer needed and should be deleted to avoid accidentally committing it to the repo.
 
+On Windows, the secrets are automatically stored and retrieved from `%APPDATA%\Microsoft\UserSecrets\<user_secrets_id>\secrets.json`. On macOS / Linux, the location is `~/.microsoft/usersecrets/<user_secrets_id>/secrets.json`.
 Running the application in Visual Studio Code should be OS agnostic. The local Docker container for the API, however, mounts the secrets file when brought up using `docker-compose`. Since they are stored at a different location for macOS / Linux, review the following lines in the main `docker-compose.yml`:
 ```yaml
 volumes:


### PR DESCRIPTION
After a few instances of confusion around setting local backend secrets I've updated the documentation slightly