### PR TITLE
PRIME-2001 inappropriate appearance of Update Business License button

### DIFF
--- a/prime-angular-frontend/src/app/shared/components/site/overview-container/overview-container.component.html
+++ b/prime-angular-frontend/src/app/shared/components/site/overview-container/overview-container.component.html
@@ -72,7 +72,7 @@
                         [editRoute]="SiteRoutes.BUSINESS_LICENCE"
                         (route)="onRouteRelative($event)">
 
-    <button *ngIf="showEditRedirect && withinRenewalPeriod"
+    <button *ngIf="showEditRedirect && site.status !== SiteStatusType.IN_REVIEW && withinRenewalPeriod"
             mat-flat-button
             color="primary"
             class="mb-4"


### PR DESCRIPTION
Create a community site and submit, update the expiry date in the database to push the site into renewal, and the business licence button will be displayed, but after submission when InReview it will not be displayed.