### PR TITLE
PRIME-2036 - Fix Enrollee Remote Access Update Bug

### DIFF
--- a/prime-dotnet-webapi/ViewModels/Enrollee/RemoteAccessSiteViewModel.cs
+++ b/prime-dotnet-webapi/ViewModels/Enrollee/RemoteAccessSiteViewModel.cs
@@ -6,6 +6,7 @@ namespace Prime.ViewModels
     {
         public int Id { get; set; }
         public int EnrolleeId { get; set; }
+        public int SiteId { get; set; }
         public SiteViewModel Site { get; set; }
 
         public class SiteViewModel


### PR DESCRIPTION
Updating/submitting an `Enrollee` with Remote Site(s) fails due to the view model not having `SiteId` any more, so the de-serialized object has `SiteId = 0` which fails the foreign key constraint

Repro:
1. Create a Community Practice Site with known Remote User Certification
2. Approve Site
2. Create Enrollee With matching Certification, and add the Site as a Remote Site
3. (Optional) Submit Enrollee and Enable editing
4. Navigate to the Demographics page and hit "Save and Continue"

Update fails with a foreign key violation on RemoteAccessSite table.