### PR TITLE
Update Dependabot for NuGet

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
       interval: "weekly"
       day: "tuesday"
       time: "18:00"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "SoapCore"
   # npm dependencies - frontend
   - package-ecosystem: "npm"
     directory: "/prime-angular-frontend"


### PR DESCRIPTION
Update the dependabot file to stop suggesting major version updates for NuGet files, and stop SoapCore updates since newer versions are a breaking change.