### PR TITLE
PRIME-2057 use openshift Sentry

### DIFF
--- a/prime-dotnet-webapi/Program.cs
+++ b/prime-dotnet-webapi/Program.cs
@@ -10,6 +10,8 @@ using System.IO;
 using System.Reflection;
 
 using Prime.Configuration.Environment;
+using Sentry.AspNetCore;
+using Sentry.Serilog;
 
 namespace Prime
 {
@@ -55,6 +57,7 @@ namespace Prime
                 })
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
+                    webBuilder.UseSentry();
                     webBuilder.UseStartup<Startup>();
                 })
                 .UseSerilog();
@@ -99,6 +102,7 @@ namespace Prime
                     new JsonFormatter(),
                     $@"{path}/prime.json",
                     rollingInterval: RollingInterval.Day))
+                .WriteTo.Sentry()
                 .CreateLogger();
         }
     }

--- a/prime-dotnet-webapi/Startup.cs
+++ b/prime-dotnet-webapi/Startup.cs
@@ -250,6 +250,11 @@ namespace Prime
 
             // Matches request to an endpoint
             app.UseRouting();
+
+            // // Enable automatic tracing integration.
+            // // Make sure to put this middleware right after `UseRouting()`.
+            app.UseSentryTracing();
+
             app.UseCors(CorsPolicy);
 
             app.UseAuthentication();

--- a/prime-dotnet-webapi/prime.csproj
+++ b/prime-dotnet-webapi/prime.csproj
@@ -36,6 +36,9 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.6" />
     <PackageReference Include="QRCoder" Version="1.4.1" />
     <PackageReference Include="RazorEngine.NetCore" Version="3.1.0" />
+    <PackageReference Include="Sentry" Version="3.12.3" />
+    <PackageReference Include="Sentry.AspNetCore" Version="3.12.3" />
+    <PackageReference Include="Sentry.Serilog" Version="3.12.3" />
     <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.3" />
     <PackageReference Include="Serilog.Sinks.Async" Version="1.4.0" />


### PR DESCRIPTION
Tested on Cloud Sentry.

Will only send reports when a DSN is provided, so we can provide DSNs in Openshift as environment variable only for the environments that we want.

Need to test it with our Openshift Sentry i.e. point to Openshift Sentry Dsn when it is up and running.