### PR TITLE
Fix When Selecting HA for enrollee overview validation for OBO site

### DIFF
--- a/prime-angular-frontend/src/app/modules/enrolment/shared/services/enrolment-form-state.service.ts
+++ b/prime-angular-frontend/src/app/modules/enrolment/shared/services/enrolment-form-state.service.ts
@@ -671,9 +671,9 @@ export class EnrolmentFormStateService extends AbstractFormStateService<Enrolmen
     const hasCertification = certifications.some(c => c?.licenseNumber);
     const enrolleeHealthAuthorities = this.careSettingsForm.get('enrolleeHealthAuthorities').value as boolean[];
     const hasOboSiteForEveryChosenHealthAuth = enrolleeHealthAuthorities
-      .every((wasChosen: boolean, healthAuthorityCode: HealthAuthorityEnum) =>
+      .every((wasChosen: boolean, healthAuthorityIndex: HealthAuthorityEnum) =>
         (wasChosen)
-          ? oboSites.some(os => os.healthAuthorityCode === healthAuthorityCode)
+          ? oboSites.some(os => os.healthAuthorityCode === this.configService.healthAuthorities[healthAuthorityIndex].code)
           : true
       );
 


### PR DESCRIPTION
In the enrollee workflow 

- select care setting Health Authority
- select no certs
- add obo site info
- proceed to overview and try to submit

without fix validation fails