### PR TITLE
fix remote user navigation and form state management

### DIFF
--- a/prime-angular-frontend/src/app/lib/classes/abstract-enrolment-page.class.ts
+++ b/prime-angular-frontend/src/app/lib/classes/abstract-enrolment-page.class.ts
@@ -248,7 +248,7 @@ export abstract class AbstractEnrolmentPage<T extends AbstractFormState<unknown>
    * Check that deactivation of the view is allowed in general
    * or specifically gated on a set of allowed control names.
    */
-  private checkDeactivationIsAllowed(): boolean {
+  protected checkDeactivationIsAllowed(): boolean {
     if (!this.allowRoutingWhenDirty && this.canDeactivateAllowlist?.length) {
       return Object.keys(this.formState.form.controls)
         .filter(key => !this.canDeactivateAllowlist.includes(key))

--- a/prime-angular-frontend/src/app/lib/classes/abstract-enrolment-page.class.ts
+++ b/prime-angular-frontend/src/app/lib/classes/abstract-enrolment-page.class.ts
@@ -248,7 +248,7 @@ export abstract class AbstractEnrolmentPage<T extends AbstractFormState<unknown>
    * Check that deactivation of the view is allowed in general
    * or specifically gated on a set of allowed control names.
    */
-  protected checkDeactivationIsAllowed(): boolean {
+  private checkDeactivationIsAllowed(): boolean {
     if (!this.allowRoutingWhenDirty && this.canDeactivateAllowlist?.length) {
       return Object.keys(this.formState.form.controls)
         .filter(key => !this.canDeactivateAllowlist.includes(key))

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/remote-users-page/remote-users-page.component.html
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/remote-users-page/remote-users-page.component.html
@@ -19,13 +19,14 @@
 
     <mat-slide-toggle class="mb-3"
                       color="primary"
-                      formControlName="hasRemoteUsers">This site has remote practitioners
+                      formControlName="hasRemoteUsers"
+                      (change)="onToggleChange()">This site has remote practitioners
     </mat-slide-toggle>
 
   </form>
 
   <div class="mb-4"
-       *ngIf="addedUpdatedRemoteUser">
+       *ngIf="formState.form.dirty && formState.remoteUsers.controls.length">
     <app-alert type="success"
                icon="check_circle_outline">
       <ng-container #alertTitle
@@ -35,6 +36,21 @@
       <ng-container #alertContent
                     class="alert-content">
         Continue adding remote practitioners if this site has more.
+      </ng-container>
+    </app-alert>
+  </div>
+
+  <div class="mb-4"
+       *ngIf="formState.form.dirty && !formState.remoteUsers.controls.length">
+    <app-alert type="warning"
+               icon="check_circle_outline">
+      <ng-container #alertTitle
+                    class="alert-title">
+        Remote Practitioner removed
+      </ng-container>
+      <ng-container #alertContent
+                    class="alert-content">
+        Either add more remote users, or uncheck the toggle above.
       </ng-container>
     </app-alert>
   </div>
@@ -88,7 +104,7 @@
           type="button"
           color="primary"
           class="mb-3"
-          [routerLink]="['new']">
+          (click)="onAdd()">
     <mat-icon class="add-icon">add</mat-icon>
     Add Remote Practitioners
   </button>

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/remote-users-page/remote-users-page.component.html
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/remote-users-page/remote-users-page.component.html
@@ -26,7 +26,7 @@
   </form>
 
   <div class="mb-4"
-       *ngIf="formState.form.dirty && formState.remoteUsers.controls.length">
+       *ngIf="formState.form.dirty && !lastRemoteUserRemoved">
     <app-alert type="success"
                icon="check_circle_outline">
       <ng-container #alertTitle
@@ -41,7 +41,7 @@
   </div>
 
   <div class="mb-4"
-       *ngIf="formState.form.dirty && !formState.remoteUsers.controls.length">
+       *ngIf="formState.form.dirty && lastRemoteUserRemoved">
     <app-alert type="warning"
                icon="check_circle_outline">
       <ng-container #alertTitle

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/remote-users-page/remote-users-page.component.ts
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/remote-users-page/remote-users-page.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { FormGroup } from '@angular/forms';
+import { FormArray, FormGroup } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { KeyValue } from '@angular/common';
 
@@ -34,6 +34,8 @@ export class RemoteUsersPageComponent extends AbstractCommunitySiteRegistrationP
   public isCompleted: boolean;
   public hasNoRemoteUserError: boolean;
   public hasNoEmailError: boolean;
+  public lastRemoteUserRemoved: boolean;
+
   public SiteRoutes = SiteRoutes;
 
   constructor(
@@ -46,6 +48,8 @@ export class RemoteUsersPageComponent extends AbstractCommunitySiteRegistrationP
     router: Router
   ) {
     super(dialog, formUtilsService, siteService, siteFormStateService, siteResource);
+
+    this.lastRemoteUserRemoved = false;
 
     this.title = this.route.snapshot.data.title;
     this.routeUtils = new RouteUtils(route, router, SiteRoutes.MODULE_PATH);
@@ -63,6 +67,10 @@ export class RemoteUsersPageComponent extends AbstractCommunitySiteRegistrationP
 
   public onRemove(index: number) {
     this.formState.remoteUsers.removeAt(index);
+
+    this.lastRemoteUserRemoved = (this.formState.remoteUsers.length === 0)
+      ? true
+      : false;
 
     // After removing a remote user, always mark form as dirty
     this.formState.form.markAsDirty();


### PR DESCRIPTION
To test navigate every which way from the remote users to remote user page, and try and do actions on a dirty form and cancel.

Only one state that it doesn't handle perfectly is if a user 
- on a fresh page toggles to add remote user
- adds a remote user
- removes said user
- hits the back button

they are then prompted about unsaved changes