### PR TITLE
PRIME-2091 Switch IdentityProvider for GIS 

### DIFF
--- a/prime-angular-frontend/src/app/modules/gis-enrolment/shared/modules/gis-login/gis-login-page.component.ts
+++ b/prime-angular-frontend/src/app/modules/gis-enrolment/shared/modules/gis-login/gis-login-page.component.ts
@@ -32,7 +32,7 @@ export class GisLoginPageComponent implements OnInit {
     const redirectUri = `${this.config.loginRedirectUrl}${redirectRoute}`;
 
     this.authService.login({
-      idpHint: IdentityProviderEnum.IDIR,
+      idpHint: IdentityProviderEnum.PHSA,
       redirectUri
     });
   }


### PR DESCRIPTION
At `/gis`, on clicking "Logon with Health Authority ID", should see PHSA login page rather than IDIR login page