### PR TITLE
PRIME-2132 Update PRIME copy of PLR Identifier Types

### DIFF
--- a/prime-dotnet-webapi/Configuration/Database/Seeded Tables/IdentifierTypeConfiguration.cs
+++ b/prime-dotnet-webapi/Configuration/Database/Seeded Tables/IdentifierTypeConfiguration.cs
@@ -38,7 +38,7 @@ namespace Prime.Configuration.Database
                     new IdentifierType { Code = "2.16.840.1.113883.4.530",     Name = "RDID"     },
                     new IdentifierType { Code = "2.16.840.1.113883.3.40.2.46", Name = "MOAID"    },
                     new IdentifierType { Code = "2.16.840.1.113883.3.40.2.44", Name = "PPID"     },
-                    new IdentifierType { Code = "2.16.840.1.113883.4.538",     Name = "NAPID"    },
+                    new IdentifierType { Code = "2.16.840.1.113883.4.538",     Name = "NDID"    },
                 };
             }
         }

--- a/prime-dotnet-webapi/Migrations/20220208205331_UpdateIdentifierTypeNdid.Designer.cs
+++ b/prime-dotnet-webapi/Migrations/20220208205331_UpdateIdentifierTypeNdid.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Prime;
@@ -9,9 +10,10 @@ using Prime;
 namespace Prime.Migrations
 {
     [DbContext(typeof(ApiDbContext))]
-    partial class ApiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220208205331_UpdateIdentifierTypeNdid")]
+    partial class UpdateIdentifierTypeNdid
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/prime-dotnet-webapi/Migrations/20220208205331_UpdateIdentifierTypeNdid.cs
+++ b/prime-dotnet-webapi/Migrations/20220208205331_UpdateIdentifierTypeNdid.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Prime.Migrations
+{
+    public partial class UpdateIdentifierTypeNdid : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "IdentifierTypeLookup",
+                keyColumn: "Code",
+                keyValue: "2.16.840.1.113883.4.538",
+                column: "Name",
+                value: "NDID");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "IdentifierTypeLookup",
+                keyColumn: "Code",
+                keyValue: "2.16.840.1.113883.4.538",
+                column: "Name",
+                value: "NAPID");
+        }
+    }
+}


### PR DESCRIPTION
The result of this implementation is that distribution messages for naturopath providers should create a record with `PlrProvider.IdentifierType` equal to "NDID" rather than "NAPID".  To test:

# Create message 
This step is *not* necessary if using PLR to send the distribution message. 

Open an existing test message (e.g. `moh-prime\prime-dotnet-webapi-tests\Integration\PRPM_IN301030CA.xml`) and modify the //healthCareProvider/id node that contains the college id (that is, not CPN, IPC, or MSPID) …

![image](https://user-images.githubusercontent.com/7586665/153289415-5a5534d0-2462-40a8-89e5-ee63830c4af9.png)

… to a naturopathic doctor identifier.  For a more realistic message, //healthCareProvider/code/@code can also be updated.  For example, after changes:

![image](https://user-images.githubusercontent.com/7586665/153289471-544cb89b-ad33-4220-90eb-17ec0d62d490.png)

# Testing locally 
1. `setx PLR_INTEGRATION_CLIENT_CERT_THUMBPRINT 6FA357305008C8EA814EA98768C21783DCCA374E`
2. Start web-api in a way that ensures the PLR_INTEGRATION_CLIENT_CERT_THUMBPRINT change is part of its environment 
3. Send the message created in the earlier step against the local web-api, providing the necessary credentials (see `moh-prime\prime-dotnet-webapi-tests\Utils\Auth\client-pem-url-encoded-headers.txt`):  `curl --insecure --header "@client-pem-url-encoded-headers.txt" --data-binary "@PRPM_IN303030CA-NDID.xml" https://127.0.0.1:5001/api/PLRHL7`
4. Check new record's `PlrProvider.IdentifierType` field 


# Testing in OpenShift 
1. See `moh-prime\prime-dotnet-webapi-tests\Utils\Auth` for `client.crt` and `client.key`
2. ` curl --insecure --cert client.crt --key client.key --data-binary "@PRPM_IN303030CA-NDID.xml" https://pr-2012-mutualauth.pharmanetenrolment.gov.bc.ca/api/v1/PLRHL7`
3. Check record in `prime-pr-2012` database > `PlrProvider` table > `IdentifierType` column 


# Test using PLR IAT environment 
Currently the PLR IAT environment is pointed at [https://pr-2012-mutualauth.pharmanetenrolment.gov.bc.ca/api/v1/PLRHL7`](https://pr-2012-mutualauth.pharmanetenrolment.gov.bc.ca/api/v1/PLRHL7%60) for PRIME.  Contact Alan, Jason, or James for PLR IAT credentials. 

1. Install client cert 
2. Go to https://plriat.hlth.gov.bc.ca/plr which will prompt for a client cert.  Choose the one for the PLR IAT environment 
3. Enter ID 
4. Enter Password 
5. [More instructions to come once PLR IAT environment is back online]
	
There are provider records for other systems so modify the test data for PRIME or create a new record (rather than disturbing the test data of other systems).