### PR TITLE
PRIME-2118 Site Reg visual changes

### DIFF
--- a/prime-angular-frontend/src/app/modules/site-registration/pages/administrator-page/administrator-page.component.html
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/administrator-page/administrator-page.component.html
@@ -12,12 +12,15 @@
                    (selected)="onSelect($event)"></app-same-as>
 
       <ng-container appPageSubheader2Summary>
-        Directly sets up individual PharmaNet access accounts at a site or has the authority to request accounts from
-        the site's PharmaNet software vendor. May be the Signing Authority.
-      </ng-container>
-      <ng-container appPageSubheader2MoreInfo>
-        The PharmaNet Administrator could be the site's administrator, manager, HR lead, medical office assistant (MOA),
-        a practitioner, software vendor, etc.
+        <p>
+          Directly sets up individual PharmaNet access accounts at a site or has the authority to request accounts from
+          the site's PharmaNet software vendor. May be the Signing Authority.
+        </p>
+        <p>
+          The PharmaNet Administrator could be the site's administrator, manager, HR lead, medical office assistant
+          (MOA),
+          a practitioner, software vendor, etc.
+        </p>
       </ng-container>
 
       <app-page-footer [isInitialEnrolment]="!isCompleted"

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/site-management-page/site-management-page.component.html
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/site-management-page/site-management-page.component.html
@@ -33,7 +33,6 @@
 
   <section class="mb-3">
     <app-page-subheader2>
-      <ng-container appPageSubheader2Title>{{ title }}</ng-container>
       <ng-container appPageSubheader2Summary>
         Use this management page to update your information or to add multiple sites.
         <em class="emphasize">

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/site-management-page/site-management-page.component.ts
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/site-management-page/site-management-page.component.ts
@@ -34,7 +34,6 @@ import { BcscUser } from '@auth/shared/models/bcsc-user.model';
 })
 export class SiteManagementPageComponent implements OnInit {
   public busy: Subscription;
-  public title: string;
   public organization: Organization;
   public organizationSitesExpiryDates: string[];
   public organizationAgreements: OrganizationAgreementViewModel[];
@@ -58,7 +57,6 @@ export class SiteManagementPageComponent implements OnInit {
     private addressPipe: AddressPipe,
     private configCodePipe: ConfigCodePipe
   ) {
-    this.title = this.route.snapshot.data.title;
     this.routeUtils = new RouteUtils(route, router, SiteRoutes.MODULE_PATH);
   }
 


### PR DESCRIPTION
[PRIME-2118](https://bcgovmoh.atlassian.net/browse/PRIME-2118?atlOrigin=eyJpIjoiMjZjMjE3ZDI2OTA5NGYyM2FiMjYyZDA4ZTc1MTdkNWEiLCJwIjoiaiJ9)
- removed `SIte Management` subtitle on site reg management page
- moved moreInfo text to be always displayed on PharmaNet Administrator page of site registration