### PR TITLE
Fix: Enable Editing site reg handling

### DIFF
--- a/prime-angular-frontend/src/app/modules/adjudication/shared/components/site-registration-container/site-registration-container.component.html
+++ b/prime-angular-frontend/src/app/modules/adjudication/shared/components/site-registration-container/site-registration-container.component.html
@@ -49,6 +49,7 @@
                                            (delete)="onDelete($event)"
                                            (unreject)="onUnreject($event)"
                                            (escalate)="onEscalate($event)"
+                                           (enableEditing)="onEnableEditing($event)"
                                            (flag)="onToggleFlagSite($event)">
             </app-site-registration-actions>
 


### PR DESCRIPTION
Looks like over the course of admin changes the handler for enable editing in site reg fell off, this adds it back in