### PR TITLE
Fix: Stop submission with missing prescriber id

### DIFF
--- a/prime-angular-frontend/src/app/modules/enrolment/pages/overview/overview.component.ts
+++ b/prime-angular-frontend/src/app/modules/enrolment/pages/overview/overview.component.ts
@@ -82,7 +82,7 @@ export class OverviewComponent extends BaseEnrolmentPage implements OnInit {
   }
 
   public onSubmit(): void {
-    if (!this.enrolmentFormStateService.isValidSubmission) {
+    if (!this.enrolmentFormStateService.isValidSubmission || this.isMissingPharmaNetId(this.enrolment.certifications)) {
       this.enrolmentFormStateService.forms.forEach((form: FormGroup) => this.formUtilsService.logFormErrors(form));
       this.toastService.openErrorToast('Your enrolment has an error that needs to be corrected before you will be able to submit');
       return;


### PR DESCRIPTION
Did some testing of test with the couple cherry picked changes and looks like it still allowed to submit with this error

And alternative was a little more work to go through and add validation as James mentioned. I may put in a ticket to clean this all up but time was the major factor in this case.