### PR TITLE
[ops] improve startup, readiness, and liveness probes for webapi

### DIFF
--- a/infrastructure/prime-app-ephemeral-template.yml
+++ b/infrastructure/prime-app-ephemeral-template.yml
@@ -650,22 +650,22 @@ objects:
                 memory: 500Mi
             startupProbe:
               httpGet:
-                path: /api/healthcheck
+                path: /api/healthcheck?p=startup
                 port: 8080
               timeoutSeconds: 30
               failureThreshold: 30
               periodSeconds: 35
             readinessProbe:
               httpGet:
-                path: /api/healthcheck
+                path: /api/healthcheck?p=readiness
                 port: 8080
               initialDelaySeconds: 5
               periodSeconds: 5
             livenessProbe:
               httpGet:
-                path: /api/healthcheck
+                path: /api/healthcheck?p=liveness
                 port: 8080
-              failureThreshold: 1
+              failureThreshold: 3
               periodSeconds: 5
             imagePullPolicy: IfNotPresent
             terminationMessagePolicy: File

--- a/infrastructure/prime-app-template.yml
+++ b/infrastructure/prime-app-template.yml
@@ -632,7 +632,7 @@ objects:
                 protocol: TCP
             startupProbe:
               httpGet:
-                path: /api/healthcheck
+                path: /api/healthcheck?p=startup
                 port: 8080
                 scheme: HTTP
               timeoutSeconds: 30
@@ -641,7 +641,7 @@ objects:
               failureThreshold: 30
             readinessProbe:
               httpGet:
-                path: /api/healthcheck
+                path: /api/healthcheck?p=readiness
                 port: 8080
                 scheme: HTTP
               initialDelaySeconds: 5
@@ -651,13 +651,13 @@ objects:
               failureThreshold: 3
             livenessProbe:
               httpGet:
-                path: /api/healthcheck
+                path: /api/healthcheck?p=liveness
                 port: 8080
                 scheme: HTTP
               timeoutSeconds: 1
               periodSeconds: 5
               successThreshold: 1
-              failureThreshold: 1
+              failureThreshold: 3
             imagePullPolicy: IfNotPresent
             terminationMessagePolicy: File
             envFrom:


### PR DESCRIPTION
Update Kubernetes health checks for webapi.
- add param to end of api/healthcheck
- set liveness probe’s failureThreshold to 3