### PR TITLE
Make Healthchecks more Self-Documenting

### DIFF
--- a/infrastructure/prime-app-ephemeral-template.yml
+++ b/infrastructure/prime-app-ephemeral-template.yml
@@ -650,20 +650,20 @@ objects:
                 memory: 500Mi
             startupProbe:
               httpGet:
-                path: /api/healthcheck?p=startup
+                path: /api/healthcheck/startup
                 port: 8080
               timeoutSeconds: 30
               failureThreshold: 30
               periodSeconds: 35
             readinessProbe:
               httpGet:
-                path: /api/healthcheck?p=readiness
+                path: /api/healthcheck/readiness
                 port: 8080
               initialDelaySeconds: 5
               periodSeconds: 5
             livenessProbe:
               httpGet:
-                path: /api/healthcheck?p=liveness
+                path: /api/healthcheck/liveness
                 port: 8080
               failureThreshold: 3
               periodSeconds: 5

--- a/infrastructure/prime-app-template.yml
+++ b/infrastructure/prime-app-template.yml
@@ -632,7 +632,7 @@ objects:
                 protocol: TCP
             startupProbe:
               httpGet:
-                path: /api/healthcheck?p=startup
+                path: /api/healthcheck/startup
                 port: 8080
                 scheme: HTTP
               timeoutSeconds: 30
@@ -641,7 +641,7 @@ objects:
               failureThreshold: 30
             readinessProbe:
               httpGet:
-                path: /api/healthcheck?p=readiness
+                path: /api/healthcheck/readiness
                 port: 8080
                 scheme: HTTP
               initialDelaySeconds: 5
@@ -651,7 +651,7 @@ objects:
               failureThreshold: 3
             livenessProbe:
               httpGet:
-                path: /api/healthcheck?p=liveness
+                path: /api/healthcheck/liveness
                 port: 8080
                 scheme: HTTP
               timeoutSeconds: 1

--- a/prime-dotnet-webapi/Controllers/HealthcheckController.cs
+++ b/prime-dotnet-webapi/Controllers/HealthcheckController.cs
@@ -25,6 +25,9 @@ namespace Prime.Controllers
         /// Does a healthcheck that queries the care setting lookup table to wake up the database
         /// </summary>
         [HttpGet]
+        [HttpGet("liveness")]
+        [HttpGet("readiness")]
+        [HttpGet("startup")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task GetHealthcheck()
         {


### PR DESCRIPTION
Mapping multiple routes to the same healthcheck to allow the existing logging to tell which type of healthcheck was called.