### PR TITLE
Fix: re-run rules missing include

### DIFF
--- a/prime-dotnet-webapi/Services/SubmissionService.cs
+++ b/prime-dotnet-webapi/Services/SubmissionService.cs
@@ -397,6 +397,7 @@ namespace Prime.Services
         private IQueryable<Enrollee> GetBaseQueryForEnrolleeApplicationRules()
         {
             return _context.Enrollees
+                .Include(e => e.EnrolleeCareSettings)
                 .Include(e => e.Submissions)
                 .Include(e => e.Addresses)
                     .ThenInclude(ea => ea.Address)


### PR DESCRIPTION
Testing:

1. Go to admin before change and re-run rules on an enrollee. It will fail.
2. Do it after deploying the change, it will pass.

Only affects re-running the rules since in the submission service we lucked out since the enrollee it previously interacted with from the DB and cached so when we grab it again even though it doesn't have the includes it still has the careSettings attached.