### PR TITLE
Fix login cancelled alert layout

### DIFF
--- a/prime-angular-frontend/src/app/shared/components/auth/prime-enrolment-access/prime-enrolment-access.component.html
+++ b/prime-angular-frontend/src/app/shared/components/auth/prime-enrolment-access/prime-enrolment-access.component.html
@@ -1,28 +1,30 @@
 <div class="container">
   <app-banner></app-banner>
   <div class="row">
-    <app-alert *ngIf="loginCancelled"
-               type="info"
-               icon="error_outline">
-      <ng-container #alertTitle
-                    class="alert-title">
-        Login Cancelled
-      </ng-container>
-      <ng-container #alertContent
-                    class="alert-content">
-        <p>You have cancelled your login to PRIME</p>
-        <p>For assistance with PRIME, contact <app-prime-phone></app-prime-phone> or
-          <app-prime-support-email></app-prime-support-email>
-        <p>
-          For assistance logging in with the BC Services Card app, contact the Helpdesk
-          <a
+    <div *ngIf="loginCancelled"
+         class="col-sm-12">
+      <app-alert type="info"
+                 icon="error_outline">
+        <ng-container #alertTitle
+                      class="alert-title">
+          Login Cancelled
+        </ng-container>
+        <ng-container #alertContent
+                      class="alert-content">
+          <p>You have cancelled your login to PRIME</p>
+          <p>For assistance with PRIME, contact <app-prime-phone></app-prime-phone> or
+            <app-prime-support-email></app-prime-support-email>
+          <p>
+            For assistance logging in with the BC Services Card app, contact the Helpdesk
+            <a
               target="_blank"
               rel="noopener noreferrer"
               [attr.href]="bcscHelpDeskUrl">
               <u>here</u></a>.
-        </p>
-      </ng-container>
-    </app-alert>
+          </p>
+        </ng-container>
+      </app-alert>
+    </div>
     <div class="col-sm-12 logo">
 
       <app-prime-logo label="right"


### PR DESCRIPTION
The alert shouldn’t be placed between `.row` and `.col`.  A `.row` ’s only child should be a `.col` where the `.col` contains the content for the grid