### PR TITLE
Fix/site business licence upload

### DIFF
--- a/prime-angular-frontend/src/app/modules/site-registration/pages/business-licence-page/business-licence-page.component.ts
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/business-licence-page/business-licence-page.component.ts
@@ -273,7 +273,7 @@ export class BusinessLicencePageComponent extends AbstractCommunitySiteRegistrat
 
     // Create a business licence document each time a file is uploaded, and
     // update the existing business licence
-    return (documentGuid !== currentBusinessLicence.businessLicenceDocument?.documentGuid)
+    return (documentGuid && documentGuid !== currentBusinessLicence.businessLicenceDocument?.documentGuid)
       ? this.siteResource.removeBusinessLicenceDocument(siteId, currentBusinessLicence.id)
         .pipe(
           exhaustMap(() => this.siteResource.createBusinessLicenceDocument(siteId, currentBusinessLicence.id, documentGuid)),

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/overview-page/overview-page.component.html
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/overview-page/overview-page.component.html
@@ -13,7 +13,7 @@
     </ng-container>
   </app-expiry-alert>
 
-  <app-alert *ngIf="siteErrors?.deviceProviderSite"
+  <app-alert *ngIf="hasErrors()"
              type="danger"
              icon="error">
     <ng-container #alertContent
@@ -51,7 +51,7 @@
       <div class="col text-right">
         <button mat-flat-button
                 color="primary"
-                [disabled]="!accept.checked || siteErrors?.deviceProviderSite"
+                [disabled]="!accept.checked || hasErrors()"
                 (click)="onSubmit()">
           Submit
         </button>

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/overview-page/overview-page.component.ts
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/overview-page/overview-page.component.ts
@@ -202,7 +202,7 @@ export class OverviewPageComponent implements OnInit {
     this.siteFormStateService.setForm(site);
 
     this.isBusinessLicenceUpdated = this.siteFormStateService.businessLicenceFormState.isBusinessLicenceUpdated
-      || (this.siteFormStateService.businessLicenceFormState.businessLicenceGuid.value && !this.site.businessLicence.businessLicenceDocument);
+      || (this.siteFormStateService.businessLicenceFormState.businessLicenceGuid.value && !this.site.businessLicence?.businessLicenceDocument);
 
     this.siteErrors = this.getSiteErrors(site);
   }
@@ -233,8 +233,8 @@ export class OverviewPageComponent implements OnInit {
     return {
       deviceProviderSite: !site.individualDeviceProviders?.length
         && site.careSettingCode === CareSettingEnum.DEVICE_PROVIDER,
-      missingBusinessLicenceOrReason: !site.businessLicence.businessLicenceDocument
-        && !site.businessLicence.deferredLicenceReason && !this.isBusinessLicenceUpdated
+      missingBusinessLicenceOrReason: !site.businessLicence?.businessLicenceDocument
+        && !site.businessLicence?.deferredLicenceReason && !this.isBusinessLicenceUpdated
     };
   }
 }

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/overview-page/overview-page.component.ts
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/overview-page/overview-page.component.ts
@@ -147,6 +147,10 @@ export class OverviewPageComponent implements OnInit {
       );
   }
 
+  public hasErrors(): boolean {
+    return Object.values(this.siteErrors).some(val => val);
+  }
+
   public ngOnInit(): void {
     this.organization = (
       this.overviewType === 'organization' ||
@@ -186,8 +190,6 @@ export class OverviewPageComponent implements OnInit {
       };
     }
 
-    this.siteErrors = this.getSiteErrors(site);
-
     // Store a local copy of the site for overview
     this.site = site;
 
@@ -199,7 +201,10 @@ export class OverviewPageComponent implements OnInit {
     // updates when not already patched and contains changes
     this.siteFormStateService.setForm(site);
 
-    this.isBusinessLicenceUpdated = this.siteFormStateService.businessLicenceFormState.isBusinessLicenceUpdated;
+    this.isBusinessLicenceUpdated = this.siteFormStateService.businessLicenceFormState.isBusinessLicenceUpdated
+      || (this.siteFormStateService.businessLicenceFormState.businessLicenceGuid.value && !this.site.businessLicence.businessLicenceDocument);
+
+    this.siteErrors = this.getSiteErrors(site);
   }
 
   /**
@@ -227,7 +232,9 @@ export class OverviewPageComponent implements OnInit {
   private getSiteErrors(site: Site): ValidationErrors {
     return {
       deviceProviderSite: !site.individualDeviceProviders?.length
-        && site.careSettingCode === CareSettingEnum.DEVICE_PROVIDER
+        && site.careSettingCode === CareSettingEnum.DEVICE_PROVIDER,
+      missingBusinessLicenceOrReason: !site.businessLicence.businessLicenceDocument
+        && !site.businessLicence.deferredLicenceReason && !this.isBusinessLicenceUpdated
     };
   }
 }

--- a/prime-angular-frontend/src/app/shared/components/site/overview-container/overview-container.component.html
+++ b/prime-angular-frontend/src/app/shared/components/site/overview-container/overview-container.component.html
@@ -88,13 +88,8 @@
       {{ site?.pec | default }}
     </app-enrollee-property>
 
-    <app-enrollee-property *ngIf="site.businessLicence?.deferredLicenceReason"
-                           title="Deferred Business Licence Reason">
-      {{ site.businessLicence.deferredLicenceReason | default }}
-    </app-enrollee-property>
-
     <ng-container *ngIf="!admin; else businessLicenceListView">
-      <ng-container *ngIf="site.businessLicence?.businessLicenceDocument">
+      <ng-container *ngIf="site.businessLicence?.businessLicenceDocument; else deferredLicence">
 
         <app-enrollee-property title="Expiry"
                                [hasError]="!site.businessLicence?.expiryDate && withinRenewalPeriod"
@@ -117,7 +112,25 @@
         </app-enrollee-property>
 
       </ng-container>
+
+      <ng-template #deferredLicence>
+        <ng-container *ngIf="site.businessLicence?.deferredLicenceReason; else missingLicenceAndDeferral">
+          <app-enrollee-property title="Deferred Business Licence Reason">
+            {{ site.businessLicence.deferredLicenceReason | default }}
+          </app-enrollee-property>
+        </ng-container>
+        <ng-template #missingLicenceAndDeferral>
+          <app-enrollee-property [hasError]="siteErrors?.missingBusinessLicenceOrReason"
+                                 errorMessage="Must have a valid business licence or deferred reason"
+                                 title="Business Licence">
+            {{ (businessLicenceUpdated) ? "New business licence document has been uploaded for submission" : "-"}}
+          </app-enrollee-property>
+        </ng-template>
+      </ng-template>
     </ng-container>
+
+
+
 
     <ng-template #businessLicenceListView>
       <ng-container *ngFor="let businessLicence of site.businessLicences">

--- a/prime-dotnet-webapi/Controllers/SitesController.cs
+++ b/prime-dotnet-webapi/Controllers/SitesController.cs
@@ -360,7 +360,7 @@ namespace Prime.Controllers
             }
 
             var existingLicence = site.BusinessLicence;
-            var isNewDocument = existingLicence.BusinessLicenceDocument.DocumentGuid != newLicence.DocumentGuid && newLicence.DocumentGuid != null;
+            var isNewDocument = existingLicence.BusinessLicenceDocument?.DocumentGuid != newLicence.DocumentGuid && newLicence.DocumentGuid != null;
 
             if (site.ApprovedDate == null)
             {


### PR DESCRIPTION
To re-create the bug 

1. Create new site submission
2. save and submit the business licence page
3. refresh or logout/login
4. Continue through the workflow and submit your site

This can also be seen on first submission when you get to the overview page and go back to edit the business licence page.

The site will not have a document associated with the business licence.

Updated the overview and api to handle users coming back after having this bug affect them and need to add their business licence again.