### PR TITLE
Fix/renewal enrolment workflow

### DIFF
--- a/prime-angular-frontend/src/app/modules/enrolment/pages/overview/overview.component.html
+++ b/prime-angular-frontend/src/app/modules/enrolment/pages/overview/overview.component.html
@@ -6,7 +6,8 @@
                                     [inProgress]="isInitialEnrolment"></app-enrolment-progress-indicator>
 
   <div class="mb-4">
-    <app-expiry-alert [expiryDates]="enrolment?.expiryDate">
+    <app-expiry-alert *ngIf="enrolment?.currentStatus.statusCode !== EnrolmentStatus.REQUIRES_TOA"
+                      [expiryDates]="enrolment?.expiryDate">
       <ng-container #alertTitle
                     class="alert-title">
         Your enrolment requires renewal
@@ -16,6 +17,21 @@
         Renew your enrolment by {{ enrolment?.expiryDate | formatDate | default }} to maintain your access to PharmaNet.
       </ng-container>
     </app-expiry-alert>
+
+    <app-alert *ngIf="enrolment?.expiryDate && enrolment?.currentStatus.statusCode === EnrolmentStatus.REQUIRES_TOA"
+               type="warning"
+               icon="warning">
+      <ng-container #alertTitle
+                    class="alert-title">
+        Pending Terms of Access
+      </ng-container>
+      <ng-container #alertContent
+                    class="alert-content">
+        You currently have terms of access that is pending acceptance, please use the link below to accept those terms.
+        <br/>
+        <a [routerLink]="" (click)="routeTo(EnrolmentRoutes.PENDING_ACCESS_TERM)">Terms of Access</a>
+      </ng-container>
+    </app-alert>
 
     <app-alert *ngIf="enrolleeAbsence"
                type="danger"
@@ -194,8 +210,9 @@
                        (route)="routeTo($event)"></app-enrollee-review>
 
   <div class="footer mb-4">
-    <app-alert *ngIf="enrolment && currentStatus !== EnrolmentStatus.EDITABLE"
-               type="danger"
+
+    <app-alert *ngIf="enrolment && currentStatus === EnrolmentStatus.UNDER_REVIEW"
+               type="warning"
                icon="warning">
       <ng-container #alertContent
                     class="alert-content">
@@ -205,6 +222,17 @@
         or
         <app-prime-support-email></app-prime-support-email>
         .
+      </ng-container>
+    </app-alert>
+
+    <app-alert *ngIf="enrolment && currentStatus === EnrolmentStatus.REQUIRES_TOA"
+               type="warning"
+               icon="warning">
+      <ng-container #alertContent
+                    class="alert-content">
+        Your enrolment is awaiting acceptance of new terms of access. To read and accept them, use the link below.
+        <br>
+        <a [routerLink]="" (click)="routeTo(EnrolmentRoutes.PENDING_ACCESS_TERM)">Terms of Access</a>
       </ng-container>
     </app-alert>
 

--- a/prime-angular-frontend/src/app/modules/enrolment/pages/overview/overview.component.html
+++ b/prime-angular-frontend/src/app/modules/enrolment/pages/overview/overview.component.html
@@ -27,7 +27,8 @@
       </ng-container>
       <ng-container #alertContent
                     class="alert-content">
-        You currently have terms of access that is pending acceptance, please use the link below to accept those terms.
+        You must accept the user terms of access to complete your renewal. Please use the link below to go to the Terms
+        of Access.
         <br/>
         <a [routerLink]="" (click)="routeTo(EnrolmentRoutes.PENDING_ACCESS_TERM)">Terms of Access</a>
       </ng-container>
@@ -230,7 +231,8 @@
                icon="warning">
       <ng-container #alertContent
                     class="alert-content">
-        Your enrolment is awaiting acceptance of new terms of access. To read and accept them, use the link below.
+        You must accept the user terms of access to complete your renewal. Please use the link below to go to the Terms
+        of Access.
         <br>
         <a [routerLink]="" (click)="routeTo(EnrolmentRoutes.PENDING_ACCESS_TERM)">Terms of Access</a>
       </ng-container>

--- a/prime-angular-frontend/src/app/shared/components/auth/prime-enrolment-access/prime-enrolment-access.component.html
+++ b/prime-angular-frontend/src/app/shared/components/auth/prime-enrolment-access/prime-enrolment-access.component.html
@@ -66,7 +66,7 @@
           <h2>BC Services Card</h2>
 
           <p>
-            Set up the BC Services Card app on a mobile device, if you haven’t done so already. Once finished, come back
+            Set up the BC Services Card app on a mobile device if you haven’t done so already. Once finished, come back
             to PRIME and complete your enrolment.
 
             <br>


### PR DESCRIPTION
Some updates to when a user comes back to renew, and are in the manual workflow. When they log back in after being adjudicated and approved they are brought to the overview page and it is not clear they need to sign a TOA.

Added some alerts with links.

Shoe horned in a couple small wordsmithing in as well