### PR TITLE
PRIME-2226 Organization overview display error

### DIFF
--- a/prime-angular-frontend/src/app/modules/site-registration/pages/overview-page/overview-page.component.ts
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/overview-page/overview-page.component.ts
@@ -148,7 +148,7 @@ export class OverviewPageComponent implements OnInit {
   }
 
   public hasErrors(): boolean {
-    return Object.values(this.siteErrors).some(val => val);
+    return this.siteErrors ? Object.values(this.siteErrors).some(val => val) : false;
   }
 
   public ngOnInit(): void {


### PR DESCRIPTION
In the site registration workflow, navigate from the site management page to the organization overview page. You should now get there and not have a looping error that crashes your browser.