### PR TITLE
PRIME-2312 Update API with limit error

### DIFF
--- a/prime-dotnet-webapi/Controllers/ProvisionerAccessController.cs
+++ b/prime-dotnet-webapi/Controllers/ProvisionerAccessController.cs
@@ -24,6 +24,9 @@ namespace Prime.Controllers
         private readonly IEmailService _emailService;
         private readonly IBusinessEventService _businessEventService;
 
+        private const int _hpdidLimit_GetUpdatedGpids = 1000;
+        private const int _hpdidLimit_HpdidLookup = 10;
+
         public ProvisionerAccessController(
             IEnrolleeService enrolleeService,
             IEnrolmentCertificateService enrolmentCertificateService,
@@ -147,9 +150,16 @@ namespace Prime.Controllers
         [ProducesResponseType(typeof(ApiResultResponse<IEnumerable<HpdidLookup>>), StatusCodes.Status200OK)]
         public async Task<ActionResult> HpdidLookup([FromQuery] string[] hpdids)
         {
-            var result = await _enrolleeService.HpdidLookupAsync(hpdids);
+            if (hpdids != null && hpdids.Length > _hpdidLimit_HpdidLookup)
+            {
+                return BadRequest($"number of {nameof(hpdids)} should not exceed {_hpdidLimit_HpdidLookup}");
+            }
+            else
+            {
+                var result = await _enrolleeService.HpdidLookupAsync(hpdids);
 
-            return Ok(result);
+                return Ok(result);
+            }
         }
 
         // POST: api/provisioner-access/updated-gpids
@@ -168,6 +178,10 @@ namespace Prime.Controllers
             if (DateTimeOffset.MinValue.Equals(updatedSince))
             {
                 return BadRequest($"{nameof(updatedSince)} parameter is required");
+            }
+            else if (hpdids != null && hpdids.Length > _hpdidLimit_GetUpdatedGpids)
+            {
+                return BadRequest($"number of {nameof(hpdids)} should not exceed {_hpdidLimit_GetUpdatedGpids}");
             }
             else
             {


### PR DESCRIPTION
Update API to return "Bad request" when number of hpdid exceeds the limit
- GetUpdatedGpid - limited to 1000 Hpdids
- HpdidLookup - limited to 10 Hpdids

Note: Please the postman testing collection v1.1 in Teams under PRIME Developer
![image](https://user-images.githubusercontent.com/108699279/192898999-3ed578b2-241c-4099-93fe-fd023e8ee3e7.png)
![image](https://user-images.githubusercontent.com/108699279/192899012-1b5ec968-a5a7-4d7c-9b02-c23887343ab9.png)
