### PR TITLE
Updating postgress source repo

### DIFF
--- a/prime-dotnet-webapi/openshift.dockerfile
+++ b/prime-dotnet-webapi/openshift.dockerfile
@@ -63,7 +63,7 @@ COPY --from=build /opt/app-root/app/entrypoint.sh /opt/app-root/app
 
 RUN apt-get update && \
     apt-get install -yqq gpgv gnupg2 wget && \
-    echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' >  /etc/apt/sources.list.d/pgdg.list && \
+    echo 'deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main' >  /etc/apt/sources.list.d/pgdg.list && \
     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
     apt-get update && \
     apt-get install -yqq --no-install-recommends postgresql-client-10 net-tools moreutils && \


### PR DESCRIPTION
Looks like postgress removed "stretch" repo. We are using mcr.microsoft.com/dotnet/aspnet:5.0 which is based on Debian "buster".