### PR TITLE
Feature/PRIME-2306 Store Org. Agreement and ToA in document manager

### DIFF
--- a/prime-angular-frontend/src/app/modules/enrolment/pages/access-agreement-current/access-agreement-current.component.html
+++ b/prime-angular-frontend/src/app/modules/enrolment/pages/access-agreement-current/access-agreement-current.component.html
@@ -8,7 +8,8 @@
         <div class="col-6">
           Accepted on {{ accessTerm?.acceptedDate | formatDate }}.
         </div>
-        <div class="col-6 text-right">
+        <div *ngIf="accessTerm?.signedAgreement"
+             class="col-6 text-right">
           <button mat-flat-button
                   class="mb-4"
                   color="primary"

--- a/prime-angular-frontend/src/app/modules/enrolment/pages/access-agreement-current/access-agreement-current.component.html
+++ b/prime-angular-frontend/src/app/modules/enrolment/pages/access-agreement-current/access-agreement-current.component.html
@@ -4,7 +4,18 @@
 
   <app-page-subheader *ngIf="accessTerm?.acceptedDate">
     <ng-container appPageSubheaderSummary>
-      Accepted on {{ accessTerm?.acceptedDate | formatDate }}.
+      <div class="row">
+        <div class="col-6">
+          Accepted on {{ accessTerm?.acceptedDate | formatDate }}.
+        </div>
+        <div class="col-6 text-right">
+          <button mat-flat-button
+                  class="mb-4"
+                  color="primary"
+                  (click)="onDownload()">Download Terms of Access</button>
+        </div>
+      </div>
+
     </ng-container>
   </app-page-subheader>
 

--- a/prime-angular-frontend/src/app/modules/enrolment/pages/access-agreement-current/access-agreement-current.component.ts
+++ b/prime-angular-frontend/src/app/modules/enrolment/pages/access-agreement-current/access-agreement-current.component.ts
@@ -6,6 +6,7 @@ import { EnrolleeAgreement } from '@shared/models/agreement.model';
 
 import { EnrolmentResource } from '@enrolment/shared/services/enrolment-resource.service';
 import { EnrolmentService } from '@enrolment/shared/services/enrolment.service';
+import { UtilsService } from '@core/services/utils.service';
 
 @Component({
   selector: 'app-access-agreement-current',
@@ -19,6 +20,7 @@ export class AccessAgreementCurrentComponent implements OnInit {
   constructor(
     private enrolmentResource: EnrolmentResource,
     private enrolmentService: EnrolmentService,
+    private utilsService: UtilsService,
   ) { }
 
   public ngOnInit(): void {
@@ -29,5 +31,13 @@ export class AccessAgreementCurrentComponent implements OnInit {
     const enrolleeId = this.enrolmentService.enrolment.id;
     this.busy = this.enrolmentResource.getLatestAccessTerm(enrolleeId, true)
       .subscribe((accessTerm: EnrolleeAgreement) => this.accessTerm = accessTerm);
+  }
+
+  public onDownload() {
+    this.enrolmentResource
+      .getAcceptedTermsOfAccessToken(this.enrolmentService.enrolment.id)
+      .subscribe((token: string) => {
+        this.utilsService.downloadToken(token);
+      });
   }
 }

--- a/prime-angular-frontend/src/app/modules/enrolment/shared/services/enrolment-resource.service.ts
+++ b/prime-angular-frontend/src/app/modules/enrolment/shared/services/enrolment-resource.service.ts
@@ -487,6 +487,18 @@ export class EnrolmentResource {
       );
   }
 
+  public getAcceptedTermsOfAccessToken(enrolleeId: number): Observable<string> {
+    return this.apiResource.get<string>(`enrollees/${enrolleeId}/agreement`)
+      .pipe(
+        map((response: ApiHttpResponse<string>) => response.result),
+        catchError((error: any) => {
+          this.toastService.openErrorToast('Enrollee terms of access could not be downloaded.');
+          this.logger.error('[Enrolment] EnrolmentResource::getAcceptedTermsOfAccessToken error has occurred: ', error);
+          throw error;
+        }),
+      );
+  }
+
   // ---
   // Enrollee and Enrolment Adapters
   // ---

--- a/prime-angular-frontend/src/app/shared/models/agreement.model.ts
+++ b/prime-angular-frontend/src/app/shared/models/agreement.model.ts
@@ -8,6 +8,10 @@ export interface Agreement {
   expiryDate: string;
 }
 
+export interface SignedAgreement {
+  id: number;
+}
+
 export interface AgreementViewModel extends Agreement {
   agreementType: AgreementType;
   signedAgreementDocumentGuid: string;
@@ -15,6 +19,7 @@ export interface AgreementViewModel extends Agreement {
 
 export interface EnrolleeAgreement extends Agreement {
   enrolleeId: number;
+  signedAgreement: SignedAgreement;
 }
 
 export interface EnrolleeAgreementViewModel extends EnrolleeAgreement, AgreementViewModel { }

--- a/prime-dotnet-webapi/Controllers/EnrolleeAgreementsController.cs
+++ b/prime-dotnet-webapi/Controllers/EnrolleeAgreementsController.cs
@@ -24,6 +24,7 @@ namespace Prime.Controllers
         private readonly IEnrolleeSubmissionService _enrolleeSubmissionService;
         private readonly IRazorConverterService _razorConverterService;
         private readonly IBusinessEventService _businessEventService;
+        private readonly IDocumentService _documentService;
 
         private readonly IPdfService _pdfService;
 
@@ -33,6 +34,7 @@ namespace Prime.Controllers
             IEnrolleeSubmissionService enrolleeSubmissionService,
             IRazorConverterService razorConverterService,
             IBusinessEventService businessEventService,
+            IDocumentService documentService,
             IPdfService pdfService)
         {
             _enrolleeService = enrolleeService;
@@ -40,6 +42,7 @@ namespace Prime.Controllers
             _enrolleeSubmissionService = enrolleeSubmissionService;
             _razorConverterService = razorConverterService;
             _businessEventService = businessEventService;
+            _documentService = documentService;
             _pdfService = pdfService;
         }
 
@@ -74,6 +77,40 @@ namespace Prime.Controllers
             }
 
             return Ok(agreements);
+        }
+
+        // GET: api/enrollees/5/agreement
+        /// <summary>
+        /// Get the enrollee's current accepted agreement in PDF.
+        /// </summary>
+        /// <param name="enrolleeId"></param>
+        [HttpGet("{enrolleeId}/agreement", Name = nameof(GetEnrolleeAcceptedAgreement))]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ApiMessageResponse), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ApiResultResponse<IEnumerable<Agreement>>), StatusCodes.Status200OK)]
+        public async Task<ActionResult> GetEnrolleeAcceptedAgreement(int enrolleeId)
+        {
+            var record = await _enrolleeService.GetPermissionsRecordAsync(enrolleeId);
+            if (record == null)
+            {
+                return NotFound($"Enrollee not found with id {enrolleeId}");
+            }
+            if (!record.AccessableBy(User))
+            {
+                return Forbid();
+            }
+
+            Agreement agreement = await _enrolleeAgreementService.GetCurrentAgreementAsync(enrolleeId);
+
+            if (agreement == null)
+            {
+                return NotFound($"Agreement not found on enrollee with id {enrolleeId}");
+            }
+
+            var token = await _documentService.GetDownloadTokenForSignedAgreementDocument(agreement.Id);
+
+            return Ok(token);
         }
 
         // GET: api/enrollees/5/cards

--- a/prime-dotnet-webapi/Controllers/OrganizationsController.cs
+++ b/prime-dotnet-webapi/Controllers/OrganizationsController.cs
@@ -11,6 +11,8 @@ using Prime.Models;
 using Prime.Models.Api;
 using Prime.Services;
 using Prime.ViewModels;
+using Prime.HttpClients;
+using Prime.HttpClients.DocumentManagerApiDefinitions;
 
 namespace Prime.Controllers
 {
@@ -30,6 +32,7 @@ namespace Prime.Controllers
         private readonly IOrganizationService _organizationService;
         private readonly ISiteService _siteService;
         private readonly IPartyService _partyService;
+        private readonly IDocumentManagerClient _documentManagerClient;
 
 
         public OrganizationsController(
@@ -42,7 +45,8 @@ namespace Prime.Controllers
             IOrganizationClaimService organizationClaimService,
             IOrganizationService organizationService,
             ISiteService siteService,
-            IPartyService partyService)
+            IPartyService partyService,
+            IDocumentManagerClient documentManagerClient)
         {
             _adminService = adminService;
             _businessEventService = businessEventService;
@@ -54,6 +58,7 @@ namespace Prime.Controllers
             _organizationService = organizationService;
             _siteService = siteService;
             _partyService = partyService;
+            _documentManagerClient = documentManagerClient;
         }
 
         // GET: api/Organizations/5
@@ -484,6 +489,22 @@ namespace Prime.Controllers
             if (organization.PendingTransfer && await _organizationService.IsOrganizationTransferCompleteAsync(organizationId))
             {
                 await _organizationService.FinalizeTransferAsync(organizationId);
+            }
+
+
+            if (!organizationAgreementGuid.HasValue)
+            {
+                var filename = "Organization-Agreement.pdf";
+                // get the agreement
+                var agreement = await _organizationAgreementService.GetOrgAgreementAsync(organizationId, agreementId, true);
+                // store it into document manager
+                var documentGuid = await _documentManagerClient.SendFileAsync(new System.IO.MemoryStream(Convert.FromBase64String(agreement.AgreementContent)), filename, DestinationFolders.SignedOrgAgreements);
+                // add a record in signed organization agreement table, treat it as uploaded agreement
+                var signedAgreement = await _organizationService.AddSignedAgreementAsync(organizationId, agreementId, documentGuid, filename);
+                if (signedAgreement == null)
+                {
+                    return BadRequest("Signed Organization Agreement could not be created; network error or upload is already submitted");
+                }
             }
 
             return NoContent();

--- a/prime-dotnet-webapi/Services/AgreementService.cs
+++ b/prime-dotnet-webapi/Services/AgreementService.cs
@@ -66,12 +66,15 @@ namespace Prime.Services
                 .FirstAsync();
         }
 
-        public async Task<SignedAgreementDocument> AddSignedAgreementDocumentAsync(int agreementId, Guid documentGuid)
+        public async Task<SignedAgreementDocument> AddSignedAgreementDocumentAsync(int agreementId, Guid documentGuid, string filename = "")
         {
-            var filename = await _documentClient.FinalizeUploadAsync(documentGuid, DestinationFolders.SignedAgreements);
-            if (string.IsNullOrWhiteSpace(filename))
+            if (filename == null)
             {
-                return null;
+                filename = await _documentClient.FinalizeUploadAsync(documentGuid, DestinationFolders.SignedAgreements);
+                if (string.IsNullOrWhiteSpace(filename))
+                {
+                    return null;
+                }
             }
 
             var signedAgreement = new SignedAgreementDocument

--- a/prime-dotnet-webapi/Services/AgreementService.cs
+++ b/prime-dotnet-webapi/Services/AgreementService.cs
@@ -68,7 +68,7 @@ namespace Prime.Services
 
         public async Task<SignedAgreementDocument> AddSignedAgreementDocumentAsync(int agreementId, Guid documentGuid, string filename = "")
         {
-            if (filename == null)
+            if (filename == "")
             {
                 filename = await _documentClient.FinalizeUploadAsync(documentGuid, DestinationFolders.SignedAgreements);
                 if (string.IsNullOrWhiteSpace(filename))

--- a/prime-dotnet-webapi/Services/EnrolleeAgreementService.cs
+++ b/prime-dotnet-webapi/Services/EnrolleeAgreementService.cs
@@ -65,6 +65,7 @@ namespace Prime.Services
 
             var agreements = await _context.Agreements
                 .AsNoTracking()
+                .Include(at => at.SignedAgreement)
                 .Where(at => at.EnrolleeId == enrolleeId)
                 .OrderByDescending(at => at.CreatedDate)
                 .If(filters.OnlyLatest, q => q.Take(1))

--- a/prime-dotnet-webapi/Services/OrganizationService.cs
+++ b/prime-dotnet-webapi/Services/OrganizationService.cs
@@ -299,12 +299,15 @@ namespace Prime.Services
             }
         }
 
-        public async Task<SignedAgreementDocument> AddSignedAgreementAsync(int organizationId, int agreementId, Guid documentGuid)
+        public async Task<SignedAgreementDocument> AddSignedAgreementAsync(int organizationId, int agreementId, Guid documentGuid, string filename = "")
         {
-            var filename = await _documentClient.FinalizeUploadAsync(documentGuid, DestinationFolders.SignedOrgAgreements);
-            if (string.IsNullOrWhiteSpace(filename))
+            if (filename == "")
             {
-                return null;
+                filename = await _documentClient.FinalizeUploadAsync(documentGuid, DestinationFolders.SignedOrgAgreements);
+                if (string.IsNullOrWhiteSpace(filename))
+                {
+                    return null;
+                }
             }
 
             var signedAgreement = new SignedAgreementDocument

--- a/prime-dotnet-webapi/Services/Razor/RazorTemplates.cs
+++ b/prime-dotnet-webapi/Services/Razor/RazorTemplates.cs
@@ -32,6 +32,7 @@ namespace Prime.Services.Razor
         {
             public static readonly RazorTemplate<Agreement> Base = new RazorTemplate<Agreement>("/Views/Agreements/Agreement.cshtml");
             public static readonly RazorTemplate<Agreement> Pdf = new RazorTemplate<Agreement>("/Views/Agreements/AgreementPdf.cshtml");
+            public static readonly RazorTemplate<Agreement> PdfNoSignature = new RazorTemplate<Agreement>("/Views/Agreements/AgreementPdfNoSignature.cshtml");
         }
 
         public static class OrgAgreements

--- a/prime-dotnet-webapi/Services/SubmissionService.cs
+++ b/prime-dotnet-webapi/Services/SubmissionService.cs
@@ -305,8 +305,7 @@ namespace Prime.Services
                 var html = await _razorConverterService.RenderTemplateToStringAsync(RazorTemplates.Agreements.PdfNoSignature, agreement);
                 var pdfbinary = _pdfService.Generate(html);
                 var filename = "Terms-Of-Access.pdf";
-                //TODO: currently storing TOA in signed_org_agreements for now. it should be changed to TOA specific folder
-                var documentGuid = await _documentManagerClient.SendFileAsync(new System.IO.MemoryStream(pdfbinary), filename, DestinationFolders.SignedOrgAgreements);
+                var documentGuid = await _documentManagerClient.SendFileAsync(new System.IO.MemoryStream(pdfbinary), filename, DestinationFolders.SignedAgreements);
 
                 var agreementDocument = await _agreementService.AddSignedAgreementDocumentAsync(agreement.Id, documentGuid, filename);
                 if (agreementDocument == null)

--- a/prime-dotnet-webapi/Services/SubmissionService.cs
+++ b/prime-dotnet-webapi/Services/SubmissionService.cs
@@ -305,6 +305,7 @@ namespace Prime.Services
                 var html = await _razorConverterService.RenderTemplateToStringAsync(RazorTemplates.Agreements.PdfNoSignature, agreement);
                 var pdfbinary = _pdfService.Generate(html);
                 var filename = "Terms-Of-Access.pdf";
+                //TODO: currently storing TOA in signed_org_agreements for now. it should be changed to TOA specific folder
                 var documentGuid = await _documentManagerClient.SendFileAsync(new System.IO.MemoryStream(pdfbinary), filename, DestinationFolders.SignedOrgAgreements);
 
                 var agreementDocument = await _agreementService.AddSignedAgreementDocumentAsync(agreement.Id, documentGuid, filename);

--- a/prime-dotnet-webapi/Services/SubmissionService.cs
+++ b/prime-dotnet-webapi/Services/SubmissionService.cs
@@ -299,12 +299,14 @@ namespace Prime.Services
             }
             else
             {
+                // for regular enrollee, get the pending agreement, create the PDF and store it in document manager
                 var pendingAgreementId = enrollee.Agreements.OrderByDescending(a => a.CreatedDate).Select(a => a.Id).First();
                 Agreement agreement = await _enrolleeAgreementService.GetEnrolleeAgreementAsync(enrollee.Id, pendingAgreementId, true);
                 var html = await _razorConverterService.RenderTemplateToStringAsync(RazorTemplates.Agreements.PdfNoSignature, agreement);
                 var pdfbinary = _pdfService.Generate(html);
                 var filename = "Terms-Of-Access.pdf";
                 var documentGuid = await _documentManagerClient.SendFileAsync(new System.IO.MemoryStream(pdfbinary), filename, DestinationFolders.SignedOrgAgreements);
+
                 var agreementDocument = await _agreementService.AddSignedAgreementDocumentAsync(agreement.Id, documentGuid, filename);
                 if (agreementDocument == null)
                 {

--- a/prime-dotnet-webapi/Services/interfaces/IAgreementService.cs
+++ b/prime-dotnet-webapi/Services/interfaces/IAgreementService.cs
@@ -11,7 +11,7 @@ namespace Prime.Services
         Task<IEnumerable<AgreementVersionListViewModel>> GetLatestAgreementVersionsAsync(AgreementGroup? group);
         Task<AgreementVersionViewModel> GetAgreementVersionAsync(int agreementVersionId);
         Task<int> GetLatestAgreementVersionIdOfTypeAsync(AgreementType type);
-        Task<SignedAgreementDocument> AddSignedAgreementDocumentAsync(int agreementId, Guid documentGuid);
+        Task<SignedAgreementDocument> AddSignedAgreementDocumentAsync(int agreementId, Guid documentGuid, string filename = "");
         Task<SignedAgreementDocument> GetSignedAgreementDocumentAsync(int agreementId);
     }
 }

--- a/prime-dotnet-webapi/Services/interfaces/IOrganizationService.cs
+++ b/prime-dotnet-webapi/Services/interfaces/IOrganizationService.cs
@@ -20,7 +20,7 @@ namespace Prime.Services
         Task<Organization> GetOrganizationNoTrackingAsync(int organizationId);
         Task<Agreement> EnsureUpdatedOrgAgreementAsync(int organizationId, int careSettingCode, int signingAuthorityId);
         Task AcceptOrgAgreementAsync(int organizationId, int agreementId);
-        Task<SignedAgreementDocument> AddSignedAgreementAsync(int organizationId, int agreementId, Guid documentGuid);
+        Task<SignedAgreementDocument> AddSignedAgreementAsync(int organizationId, int agreementId, Guid documentGuid, string filename = "");
         Task<SignedAgreementDocument> GetLatestSignedAgreementAsync(int organizationId);
         Task<IEnumerable<CareSettingType>> GetCareSettingCodesForPendingTransferAsync(int organizationId, int signingAuthorityId);
         Task FinalizeTransferAsync(int organizationId);

--- a/prime-dotnet-webapi/Views/Agreements/AgreementPdfNoSignature.cshtml
+++ b/prime-dotnet-webapi/Views/Agreements/AgreementPdfNoSignature.cshtml
@@ -1,0 +1,14 @@
+@using Prime.Models
+@model Agreement
+
+@{
+  Layout = "~/Views/Partials/_BaseLayout.cshtml";
+}
+
+@section Title { Terms of Access }
+
+@section Theme {
+@await Html.PartialAsync("~/Views/Partials/_AgreementTheme.cshtml")
+}
+
+@await Html.PartialAsync("Agreement.cshtml")

--- a/prime-dotnet-webapi/Views/Agreements/AgreementPdfNoSignature.cshtml
+++ b/prime-dotnet-webapi/Views/Agreements/AgreementPdfNoSignature.cshtml
@@ -8,7 +8,7 @@
 @section Title { Terms of Access }
 
 @section Theme {
-@await Html.PartialAsync("~/Views/Partials/_AgreementTheme.cshtml")
+  @await Html.PartialAsync("~/Views/Partials/_AgreementTheme.cshtml")
 }
 
 @await Html.PartialAsync("Agreement.cshtml")


### PR DESCRIPTION
Note:
- Organization Agreement PDF will be created and stored in Document Manager. Then it will be treated as uploaded agreement PDF that a record will be created in SignedAgreementDocument table as a reference. 
- Similar to Organization Agreement, TOA PDF will be created and stored in Document Manager, and a record will be created in SignedAgreementDocument table. 
- Default filename of the organization agreement is "Organization-Agreement.pdf", which matches the name in the existing frontend code.
- Default filename of the TOA is "Terms-of-Access.pdf", which matches the name in the existing frontend code.
- TOA PDF can be downloaded from Terms-of-Access page logged as Enrollee. However, it can't be downloaded by Admin at this point.
![image](https://user-images.githubusercontent.com/108699279/200974939-f7a90c4b-f863-48eb-b043-111c5391fa1e.png)


https://pr-2222.pharmanetenrolment.gov.bc.ca/info
