### PR TITLE
PRIME-2361 Adapt to CHES API changes

### DIFF
--- a/prime-dotnet-webapi-tests/testsettings.json
+++ b/prime-dotnet-webapi-tests/testsettings.json
@@ -37,10 +37,10 @@
   },
   "ChesApi": {
     "Enabled": false,
-    "Url": "https://ches-dev.apps.silver.devops.gov.bc.ca/api/v1",
-    "ClientId": "PRIME_SERVICE_CLIENT",
+    "Url": "https://ches-dev.api.gov.bc.ca/api/v1",
+    "ClientId": "<redacted>",
     "ClientSecret": "<redacted>",
-    "TokenUrl": "https://dev.oidc.gov.bc.ca/auth/realms/jbd6rnxw/protocol/openid-connect"
+    "TokenUrl": "https://dev.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect"
   },
   "VerifiableCredentialApi": {
     "Url": "http://agent:8024/",

--- a/prime-dotnet-webapi/Configuration/Environment/PrimeEnvironmentVariablesConfigurationProvider.cs
+++ b/prime-dotnet-webapi/Configuration/Environment/PrimeEnvironmentVariablesConfigurationProvider.cs
@@ -51,6 +51,7 @@ namespace Prime.Configuration.Environment
 
                 "CHES_ENABLED" => "ChesApi__Enabled",
                 "CHES_API_URL" => "ChesApi__Url",
+                "CHES_CLIENT_ID" => "ChesApi__ClientId",
                 "CHES_CLIENT_SECRET" => "ChesApi__ClientSecret",
                 "CHES_TOKEN_URL" => "ChesApi__TokenUrl",
 

--- a/prime-dotnet-webapi/HttpClients/Mail/ChesClient.cs
+++ b/prime-dotnet-webapi/HttpClients/Mail/ChesClient.cs
@@ -81,6 +81,10 @@ namespace Prime.HttpClients.Mail
             try
             {
                 HttpResponseMessage response = await _client.GetAsync("health");
+                if (!response.IsSuccessStatusCode)
+                {
+                    _logger.LogError($"CHES Healthcheck returned {response.StatusCode}");
+                }
                 return response.IsSuccessStatusCode;
             }
             catch (Exception ex)

--- a/prime-dotnet-webapi/appsettings.json
+++ b/prime-dotnet-webapi/appsettings.json
@@ -37,10 +37,10 @@
   },
   "ChesApi": {
     "Enabled": false,
-    "Url": "https://ches-dev.apps.silver.devops.gov.bc.ca/api/v1",
-    "ClientId": "PRIME_SERVICE_CLIENT",
+    "Url": "https://ches-dev.api.gov.bc.ca/api/v1",
+    "ClientId": "<redacted>",
     "ClientSecret": "<redacted>",
-    "TokenUrl": "https://dev.oidc.gov.bc.ca/auth/realms/jbd6rnxw/protocol/openid-connect"
+    "TokenUrl": "https://dev.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect"
   },
   "VerifiableCredentialApi": {
     "Url": "http://agent:8024/",


### PR DESCRIPTION
Best to test in PR environment:  https://pr-2249.pharmanetenrolment.gov.bc.ca/


Set `CHES_ENABLED` to true, and delete the `webapi` pod so that a new one reads the ConfigMap update:
![image](https://user-images.githubusercontent.com/7586665/208579031-f0289d81-c63c-4174-b8ae-f922fa121caa.png)


Note that this can then send to legitimate email addresses, e.g.
![image](https://user-images.githubusercontent.com/7586665/208579465-077d4192-c68f-4bb4-a073-0e6b9eff0ea7.png)


For DevOps purposes, a new secret key is needed in each PRIME OC project (e.g. test, prod)
![image](https://user-images.githubusercontent.com/7586665/208579777-05cb6c0d-0090-4303-86d1-e64ec58d64f6.png)



