### PR TITLE
PRIME-2332 Health Authority Site Registration - Vendor selection limited by care type

### DIFF
--- a/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/health-auth-care-type-page/health-auth-care-type-form-state.class.ts
+++ b/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/health-auth-care-type-page/health-auth-care-type-form-state.class.ts
@@ -4,6 +4,7 @@ import { AbstractFormState } from '@lib/classes/abstract-form-state.class';
 import { FormControlValidators } from '@lib/validators/form-control.validators';
 import { HealthAuthorityService } from '@health-auth/shared/services/health-authority.service';
 import { HealthAuthCareTypeForm } from './health-auth-care-type-form.model';
+import { HealthAuthorityVendor } from '@health-auth/shared/models/health-authority-vendor.model';
 
 export class HealthAuthCareTypeFormState extends AbstractFormState<HealthAuthCareTypeForm> {
   public constructor(
@@ -31,8 +32,12 @@ export class HealthAuthCareTypeFormState extends AbstractFormState<HealthAuthCar
     const { healthAuthorityCareTypeId, healthAuthorityVendorId } = this.formInstance.getRawValue();
     const healthAuthorityCareType = this.healthAuthorityService.healthAuthority.careTypes
       .find(hact => hact.id === healthAuthorityCareTypeId);
-    const healthAuthorityVendor = this.healthAuthorityService.healthAuthority.vendors
-      .find(hav => hav.id === healthAuthorityVendorId);
+    const healthAuthorityVendor: HealthAuthorityVendor = {
+      healthAuthorityCareTypeId: healthAuthorityCareTypeId,
+      id: healthAuthorityVendorId,
+      // Not available at this point and not required downstream
+      vendorCode: null
+    };
 
     return { healthAuthorityCareType, healthAuthorityVendor };
   }

--- a/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/health-auth-care-type-page/health-auth-care-type-page.component.html
+++ b/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/health-auth-care-type-page/health-auth-care-type-page.component.html
@@ -35,7 +35,8 @@
       </div>
     </section>
 
-    <section class="mb-3">
+    <section *ngIf="vendors?.length"
+             class="mb-3">
       <app-page-subheader2>
         <ng-container appPageSubheader2Title>Vendor</ng-container>
         <ng-container appPageSubheader2Summary>

--- a/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/health-auth-care-type-page/health-auth-care-type-page.component.ts
+++ b/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/health-auth-care-type-page/health-auth-care-type-page.component.ts
@@ -95,7 +95,6 @@ export class HealthAuthCareTypePageComponent extends AbstractHealthAuthoritySite
 
     const site = this.healthAuthoritySiteService.site;
     this.healthAuthorityCareTypes = this.route.snapshot.data.healthAuthority?.careTypes ?? [];
-    this.vendors = this.route.snapshot.data.healthAuthority?.vendors ?? [];
     this.isCompleted = site?.completed;
     this.isSubmitted = site?.submittedDate ? true : false;
     this.healthAuthoritySiteFormStateService.setForm(site, !this.hasBeenSubmitted);

--- a/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/health-auth-care-type-page/health-auth-care-type-page.component.ts
+++ b/prime-angular-frontend/src/app/modules/health-auth-site-reg/pages/health-auth-care-type-page/health-auth-care-type-page.component.ts
@@ -64,6 +64,21 @@ export class HealthAuthCareTypePageComponent extends AbstractHealthAuthoritySite
 
   public ngOnInit(): void {
     this.createFormInstance();
+
+    // Add handler then ...
+    this.formState.healthAuthorityCareTypeId.valueChanges
+      .pipe(
+        map((selectedCareType: number) =>
+          this.healthAuthorityCareTypes.find((haCareType: HealthAuthorityCareType) => haCareType.id == selectedCareType).vendors
+        )
+      )
+      .subscribe((filteredVendors: HealthAuthorityVendor[]) => {
+        this.vendors = filteredVendors;
+        // Clear any vendor selection since changed care type
+        this.formState.healthAuthorityVendorId.patchValue(null);
+      });
+
+    // ... patch form (invoking handler)
     this.patchForm();
   }
 

--- a/prime-angular-frontend/src/app/modules/health-auth-site-reg/shared/models/health-authority-care-type.model.ts
+++ b/prime-angular-frontend/src/app/modules/health-auth-site-reg/shared/models/health-authority-care-type.model.ts
@@ -1,5 +1,8 @@
+import { HealthAuthorityVendor } from './health-authority-vendor.model';
+
 export interface HealthAuthorityCareType {
   id: number;
   healthAuthorityOrganizationId: number;
   careType: string;
+  vendors: HealthAuthorityVendor[];
 }

--- a/prime-angular-frontend/src/app/modules/health-auth-site-reg/shared/models/health-authority-vendor.model.ts
+++ b/prime-angular-frontend/src/app/modules/health-auth-site-reg/shared/models/health-authority-vendor.model.ts
@@ -1,5 +1,8 @@
 export interface HealthAuthorityVendor {
   id: number;
-  healthAuthorityOrganizationId: number;
+  // One of `healthAuthorityOrganizationId` or `healthAuthorityCareTypeId`
+  // will be set, depending on the context
+  healthAuthorityOrganizationId?: number;
+  healthAuthorityCareTypeId?: number;
   vendorCode: number;
 }

--- a/prime-angular-frontend/src/test/mocks/mock-health-authority-site.service.ts
+++ b/prime-angular-frontend/src/test/mocks/mock-health-authority-site.service.ts
@@ -15,18 +15,20 @@ export class MockHealthAuthoritySiteService {
   constructor() {
     const siteId = faker.random.number();
     const address = new Address('CA', 'BC', faker.address.streetAddress(), '', faker.address.city(), faker.address.zipCode());
+    const aHealthAuthorityVendor = {
+      id: faker.random.number(),
+      healthAuthorityOrganizationId: faker.random.number(),
+      vendorCode: faker.random.number()
+    };
     const healthAuthoritySite = HealthAuthoritySite.toHealthAuthoritySite({
       id: siteId,
       healthAuthorityOrganizationId: HealthAuthorityEnum.INTERIOR_HEALTH,
-      healthAuthorityVendor: {
-        id: faker.random.number(),
-        healthAuthorityOrganizationId: faker.random.number(),
-        vendorCode: faker.random.number()
-      },
+      healthAuthorityVendor: aHealthAuthorityVendor,
       healthAuthorityCareType: {
         id: faker.random.number(),
         healthAuthorityOrganizationId: faker.random.number(),
-        careType: faker.random.words(1)
+        careType: faker.random.words(1),
+        vendors: [aHealthAuthorityVendor]
       },
       siteName: faker.random.words(2),
       pec: faker.random.number().toString(),

--- a/prime-dotnet-webapi/ApiDbContext.cs
+++ b/prime-dotnet-webapi/ApiDbContext.cs
@@ -97,6 +97,7 @@ namespace Prime
         public DbSet<HealthAuthorityVendor> HealthAuthorityVendors { get; set; }
         public DbSet<PrivacyOffice> PrivacyOffices { get; set; }
         public DbSet<HealthAuthorityTechnicalSupportVendor> HealthAuthorityTechnicalSupportVendors { get; set; }
+        public DbSet<HealthAuthorityCareTypeToVendor> HealthAuthorityCareTypeToVendors { get; set; }
 
         public DbSet<SelfDeclarationDocument> SelfDeclarationDocuments { get; set; }
         public DbSet<IdentificationDocument> IdentificationDocuments { get; set; }

--- a/prime-dotnet-webapi/Migrations/20230215025133_SeparateHACareTypeToVendorRelationship.Designer.cs
+++ b/prime-dotnet-webapi/Migrations/20230215025133_SeparateHACareTypeToVendorRelationship.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Prime;
@@ -9,9 +10,10 @@ using Prime;
 namespace Prime.Migrations
 {
     [DbContext(typeof(ApiDbContext))]
-    partial class ApiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230215025133_SeparateHACareTypeToVendorRelationship")]
+    partial class SeparateHACareTypeToVendorRelationship
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/prime-dotnet-webapi/Migrations/20230215025133_SeparateHACareTypeToVendorRelationship.cs
+++ b/prime-dotnet-webapi/Migrations/20230215025133_SeparateHACareTypeToVendorRelationship.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+namespace Prime.Migrations
+{
+    public partial class SeparateHACareTypeToVendorRelationship : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "HealthAuthorityCareTypeToVendor",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    HealthAuthorityCareTypeId = table.Column<int>(type: "integer", nullable: false),
+                    HealthAuthorityVendorId = table.Column<int>(type: "integer", nullable: false),
+                    CreatedUserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CreatedTimeStamp = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UpdatedUserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    UpdatedTimeStamp = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_HealthAuthorityCareTypeToVendor", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_HealthAuthorityCareTypeToVendor_HealthAuthorityCareType_Hea~",
+                        column: x => x.HealthAuthorityCareTypeId,
+                        principalTable: "HealthAuthorityCareType",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_HealthAuthorityCareTypeToVendor_HealthAuthorityVendor_Healt~",
+                        column: x => x.HealthAuthorityVendorId,
+                        principalTable: "HealthAuthorityVendor",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_HealthAuthorityCareTypeToVendor_HealthAuthorityCareTypeId",
+                table: "HealthAuthorityCareTypeToVendor",
+                column: "HealthAuthorityCareTypeId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_HealthAuthorityCareTypeToVendor_HealthAuthorityVendorId",
+                table: "HealthAuthorityCareTypeToVendor",
+                column: "HealthAuthorityVendorId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "HealthAuthorityCareTypeToVendor");
+        }
+    }
+}

--- a/prime-dotnet-webapi/Models/Health Authorities/HealthAuthorityCareTypeToVendor.cs
+++ b/prime-dotnet-webapi/Models/Health Authorities/HealthAuthorityCareTypeToVendor.cs
@@ -1,0 +1,23 @@
+using System.Text.Json.Serialization;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Prime.Models.HealthAuthorities
+{
+    [Table("HealthAuthorityCareTypeToVendor")]
+    public class HealthAuthorityCareTypeToVendor : BaseAuditable
+    {
+        [Key]
+        public int Id { get; set; }
+
+        public int HealthAuthorityCareTypeId { get; set; }
+
+        [JsonIgnore]
+        public HealthAuthorityCareType HealthAuthorityCareType { get; set; }
+
+        public int HealthAuthorityVendorId { get; set; }
+
+        [JsonIgnore]
+        public HealthAuthorityVendor HealthAuthorityVendor { get; set; }
+    }
+}

--- a/prime-dotnet-webapi/Services/HealthAuthorityService.cs
+++ b/prime-dotnet-webapi/Services/HealthAuthorityService.cs
@@ -58,10 +58,20 @@ namespace Prime.Services
 
         public async Task<HealthAuthorityViewModel> GetHealthAuthorityAsync(int id)
         {
-            return await _context.HealthAuthorities
+            HealthAuthorityViewModel healthAuthority = await _context.HealthAuthorities
                 .AsNoTracking()
                 .ProjectTo<HealthAuthorityViewModel>(_mapper.ConfigurationProvider)
                 .SingleOrDefaultAsync(ha => ha.Id == id);
+            foreach (HealthAuthorityCareTypeViewModel careType in healthAuthority.CareTypes)
+            {
+                careType.Vendors = await _context.HealthAuthorityCareTypeToVendors
+                    .AsNoTracking()
+                    .Where(ct2v => ct2v.HealthAuthorityCareTypeId == careType.Id)
+                    .Select(ct2v => ct2v.HealthAuthorityVendor)
+                    .ProjectTo<HealthAuthorityVendorViewModel>(_mapper.ConfigurationProvider)
+                    .ToListAsync();
+            }
+            return healthAuthority;
         }
 
         // TODO: review this VM

--- a/prime-dotnet-webapi/ViewModels/Health Authorities/HealthAuthorityCareTypeViewModel.cs
+++ b/prime-dotnet-webapi/ViewModels/Health Authorities/HealthAuthorityCareTypeViewModel.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using FluentValidation;
 
 namespace Prime.ViewModels.HealthAuthoritySites
@@ -7,6 +8,7 @@ namespace Prime.ViewModels.HealthAuthoritySites
         public int Id { get; set; }
         public int HealthAuthorityOrganizationId { get; set; }
         public string CareType { get; set; }
+        public IEnumerable<HealthAuthorityVendorViewModel> Vendors { get; set; }
     }
 
     public class HealthAuthorityCareTypeValidator : AbstractValidator<HealthAuthorityCareTypeViewModel>

--- a/prime-dotnet-webapi/ViewModels/Health Authorities/HealthAuthorityViewModel.cs
+++ b/prime-dotnet-webapi/ViewModels/Health Authorities/HealthAuthorityViewModel.cs
@@ -9,6 +9,10 @@ namespace Prime.ViewModels.HealthAuthorities
         public int Id { get; set; }
         public string Name { get; set; }
         public IEnumerable<HealthAuthorityCareTypeViewModel> CareTypes { get; set; }
+        /// <summary>
+        /// All vendors used at a Health Authority, not filtered by a Care Type
+        /// </summary>
+        public IEnumerable<HealthAuthorityVendorViewModel> Vendors { get; set; }
         public PrivacyOfficeViewModel PrivacyOffice { get; set; }
         public IEnumerable<TechnicalSupportContactViewModel> TechnicalSupports { get; set; }
         public IEnumerable<HealthAuthorityContactViewModel> PharmanetAdministrators { get; set; }

--- a/prime-dotnet-webapi/ViewModels/Health Authorities/HealthAuthorityViewModel.cs
+++ b/prime-dotnet-webapi/ViewModels/Health Authorities/HealthAuthorityViewModel.cs
@@ -9,7 +9,6 @@ namespace Prime.ViewModels.HealthAuthorities
         public int Id { get; set; }
         public string Name { get; set; }
         public IEnumerable<HealthAuthorityCareTypeViewModel> CareTypes { get; set; }
-        public IEnumerable<HealthAuthorityVendorViewModel> Vendors { get; set; }
         public PrivacyOfficeViewModel PrivacyOffice { get; set; }
         public IEnumerable<TechnicalSupportContactViewModel> TechnicalSupports { get; set; }
         public IEnumerable<HealthAuthorityContactViewModel> PharmanetAdministrators { get; set; }


### PR DESCRIPTION
Review this PR rather than https://github.com/bcgov/moh-prime/pull/2261

To test, the new table `HealthAuthorityCareTypeToVendor` needs to be populated.  For example, given 

![image](https://user-images.githubusercontent.com/7586665/219281720-1ec87a58-1970-415a-be45-00922ccb94bd.png)
and 
![image](https://user-images.githubusercontent.com/7586665/219281747-98e430b3-8eb5-443a-8487-edd2ebb1cff2.png)

`HealthAuthorityCareTypeToVendor` could be setup like this:
![image](https://user-images.githubusercontent.com/7586665/219281782-68495d0a-8290-498a-b3ca-850d1e44de03.png)

Registering a Health Authority Site should filter Vendor choices based on the Care Type selected.  Editing a Health Authority through the Admin screens should be unaffected and continue to work properly.
