### PR TITLE
PRIME-2457 Handle invalid email address during SendEnrolleeRenewalEmails

### DIFF
--- a/prime-dotnet-webapi/Controllers/EmailsController.cs
+++ b/prime-dotnet-webapi/Controllers/EmailsController.cs
@@ -59,12 +59,14 @@ namespace Prime.Controllers
         public async Task<ActionResult> SendEnrolleeRenewalEmails()
         {
             var enrolleesEmailed = await _emailService.SendEnrolleeRenewalEmails();
+            int numEmailed = 0;
             foreach (var enrolleeId in enrolleesEmailed)
             {
                 await _businessEventService.CreateEmailEventAsync(enrolleeId, "Notified enrollee to renew");
+                numEmailed++;
             }
 
-            return NoContent();
+            return Ok($"Sent {numEmailed} renewal emails.");
         }
 
         // POST: api/Emails/management/enrollees/unsigned-toa

--- a/prime-dotnet-webapi/HttpClients/Mail/ChesClient.cs
+++ b/prime-dotnet-webapi/HttpClients/Mail/ChesClient.cs
@@ -60,7 +60,9 @@ namespace Prime.HttpClients.Mail
                 if (response.IsSuccessStatusCode)
                 {
                     var statusResponse = JsonConvert.DeserializeObject<IEnumerable<StatusResponse>>(responseString);
-                    return statusResponse.Single().Status;
+                    // The IEnumerable can contain no elements if CHES API is asked about a `msgId` that wasn't sent
+                    // with the current CHES credentials
+                    return statusResponse.SingleOrDefault()?.Status;
                 }
                 else
                 {

--- a/prime-dotnet-webapi/Services/EmailService.cs
+++ b/prime-dotnet-webapi/Services/EmailService.cs
@@ -431,8 +431,15 @@ namespace Prime.Services
             }
 
             // Allways fall back to smtp
-            await _smtpEmailClient.SendAsync(email);
-            await CreateEmailLog(email, SendType.Smtp);
+            try
+            {
+                await _smtpEmailClient.SendAsync(email);
+                await CreateEmailLog(email, SendType.Smtp);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError($"Failed to send email to {email.To}, using SMTP", e);
+            }
         }
 
         private async Task CreateEmailLog(Email email, string sendType, Guid? msgId = null)


### PR DESCRIPTION
To assist with testing, see 

![image](https://user-images.githubusercontent.com/7586665/231311786-bf9ef0d4-7110-4caf-acd2-ee2e771f36ab.png)

This PR:
- prevents invalid email addresses, as detected by `MailAddress`, from being attempted to send out
- handles errors from `SmtpEmailClient` which can occur if email address passes `MailAddress` validation but fails CHES validation

Additionally the PR: 
- provides more information in API call response
- should avoid creating "CHES Exception: Sequence contains no elements" ERR message in logs

To use CHES in the PR environment, set the following
![image](https://user-images.githubusercontent.com/7586665/234053608-4f102f85-514a-4058-ba54-56d22e8f777d.png)



