### PR TITLE
PRIME-2594 Implement fix and address performance

### DIFF
--- a/prime-dotnet-webapi/Services/SubmissionService.cs
+++ b/prime-dotnet-webapi/Services/SubmissionService.cs
@@ -220,6 +220,8 @@ namespace Prime.Services
             var pharmanetStatusReasons = new[]
             {
                 (int) StatusReasonType.BirthdateDiscrepancy,
+                // NotInPharmanet included due to earlier mistake running against non-PROD PharmaNet API
+                (int) StatusReasonType.NotInPharmanet
             };
 
             var enrollees = GetBaseQueryForEnrolleeApplicationRules()
@@ -481,7 +483,8 @@ namespace Prime.Services
                     .ThenInclude(es => es.EnrolmentStatusReasons)
                 .Include(e => e.Certifications)
                     .ThenInclude(c => c.License)
-                        .ThenInclude(l => l.LicenseDetails);
+                        .ThenInclude(l => l.LicenseDetails)
+                .AsSplitQuery();
         }
     }
 }


### PR DESCRIPTION
- not calling the Production PharmaNet API (but instead, mocked API) caused `NotInPharmanet` to be the status reason
- this fix addresses skewed data
- using `AsSplitQuery` in this context and other References should not be a problem (verified results are identical before and after using `AsSplitQuery`)