### PR TITLE
Revert "PRIME-2736 fix Cancel-TOA-Assignment feature (#2539)"

### DIFF
--- a/prime-dotnet-webapi/Services/EnrolleeSubmissionService.cs
+++ b/prime-dotnet-webapi/Services/EnrolleeSubmissionService.cs
@@ -102,8 +102,7 @@ namespace Prime.Services
             // set the self declaration version Id and add unanswered items
             // *** answered Yes - it should have self declaration ID set
             // *** answered No - it should NOT have self declaration ID
-            // At a given point in time, a SD question may not exist for a particular SD type so the `selfDeclarationQuestions` list may contain null elements
-            foreach (var sd in selfDeclarationQuestions.Where(q => q != null))
+            foreach (var sd in selfDeclarationQuestions)
             {
                 if (enrollee.SelfDeclarations == null)
                 {


### PR DESCRIPTION
This reverts commit 4c9a24b5f1a22b7f22b768c541c8d8f91f9682d3.

- PRIME Business has not provided PROD deployment approval for https://github.com/bcgov/moh-prime/pull/2539
- They are more interested in https://github.com/bcgov/moh-prime/pull/2564
- If the latter PR is approved but not the former PR, Admin cannot change TOA for pre-2023 enrollments but when Enrollee logs in, Enrollee will be forced to re-edit and re-submit their enrollment anyways 