### PR TITLE
PRIME-2894 Point at Keycloak DEV (version 22) temporarily

### DIFF
--- a/document-manager/backend/.env-local
+++ b/document-manager/backend/.env-local
@@ -14,7 +14,7 @@ CACHE_REDIS_HOST=redis
 CACHE_REDIS_PORT=6379
 CACHE_REDIS_PASS=redis-password
 
-JWT_OIDC_WELL_KNOWN_CONFIG=https://common-logon-test.hlth.gov.bc.ca/auth/realms/moh_applications/.well-known/openid-configuration
+JWT_OIDC_WELL_KNOWN_CONFIG=https://common-logon-dev.hlth.gov.bc.ca/auth/realms/moh_applications/.well-known/openid-configuration
 KEYCLOAK_CLIENT_ID=PRIME-APPLICATION-LOCAL
 
 APP_ROOT=/opt/app-root

--- a/infrastructure/prime-app-ephemeral-template.yml
+++ b/infrastructure/prime-app-ephemeral-template.yml
@@ -188,7 +188,7 @@ objects:
         "documentManagerUrl": "https://${SVC_NAME}.pharmanetenrolment.gov.bc.ca/api/docman",
         "keycloakConfig": {
           "config": {
-            "url": "https://common-logon-test.hlth.gov.bc.ca/auth",
+            "url": "https://common-logon-dev.hlth.gov.bc.ca/auth",
             "realm": "moh_applications",
             "clientId": "PRIME-APPLICATION-LOCAL"
           }

--- a/prime-angular-frontend/src/environments/environment.prod.ts
+++ b/prime-angular-frontend/src/environments/environment.prod.ts
@@ -30,7 +30,7 @@ export const environment: AppEnvironment = {
   },
   keycloakConfig: {
     config: {
-      url: 'https://common-logon-test.hlth.gov.bc.ca/auth',
+      url: 'https://common-logon-dev.hlth.gov.bc.ca/auth',
       realm: 'moh_applications',
       clientId: 'PRIME-APPLICATION-LOCAL'
     },

--- a/prime-dotnet-webapi/appsettings.json
+++ b/prime-dotnet-webapi/appsettings.json
@@ -11,7 +11,7 @@
     "ClientSecret": "<redacted>"
   },
   "PrimeKeycloak": {
-    "RealmUrl": "https://common-logon-test.hlth.gov.bc.ca/auth/realms/moh_applications",
+    "RealmUrl": "https://common-logon-dev.hlth.gov.bc.ca/auth/realms/moh_applications",
     "KeycloakClientId": "PRIME-APPLICATION-LOCAL",
     "AdministrationUrl": "https://placeholder.ca",
     "AdministrationClientId": "keycloak-service-account",


### PR DESCRIPTION
Changes in commit `b11989c3342bae55463839aba9f65c8ddefb35d0` enable local testing but for the PR environment to work, also need to override the `9c33a9-dev` `keycloak` ConfigMap of: 
```
data:
  KEYCLOAK_CLIENT_ID: PRIME-APPLICATION-LOCAL
  KEYCLOAK_URL: 'https://common-logon-test.hlth.gov.bc.ca/auth'
  KEYCLOAK_REALM: moh_applications
  MOH_KEYCLOAK_ADMINISTRATION_URL: 'https://user-management-dev.api.hlth.gov.bc.ca/'
  MOH_KEYCLOAK_REALM_URL: 'https://common-logon-dev.hlth.gov.bc.ca/auth/realms/moh_applications'
  KEYCLOAK_REALM_URL: 'https://common-logon-test.hlth.gov.bc.ca/auth/realms/moh_applications'
  JWT_WELL_KNOWN_CONFIG: 'https://common-logon-test.hlth.gov.bc.ca/auth/realms/moh_applications/.well-known/openid-configuration'
  KEYCLOAK_TOKEN_URL: 'https://common-logon-test.hlth.gov.bc.ca/auth/realms/moh_applications/protocol/openid-connect/token'
  KEYCLOAK_ADMINISTRATION_URL: 'https://user-management-test.api.hlth.gov.bc.ca/'
```
with these in `pr-2699-webapi` `DeploymentConfig`
```
  JWT_WELL_KNOWN_CONFIG: 'https://common-logon-dev.hlth.gov.bc.ca/auth/realms/moh_applications/.well-known/openid-configuration'
  KEYCLOAK_REALM_URL: 'https://common-logon-dev.hlth.gov.bc.ca/auth/realms/moh_applications'
  KEYCLOAK_TOKEN_URL: 'https://common-logon-dev.hlth.gov.bc.ca/auth/realms/moh_applications/protocol/openid-connect/token'
  KEYCLOAK_URL: 'https://common-logon-dev.hlth.gov.bc.ca/auth'
```
and this in `pr-2699-document-manager` `Deployment`
```
  DOCUMENT_MANAGER_CLIENT_SECRET: <redacted>  
```

2025-03-21:  Uploading files to Document Manager **not** working
2025-03-30:  Does https://console.apps.silver.devops.gov.bc.ca/k8s/ns/9c33a9-dev/configmaps/pr-2699-env-config need to be manually updated? 

### **Do NOT merge the latest changes from develop into this branch**
