### PR TITLE
OHID-344 Remote User Issues

### DIFF
--- a/prime-angular-frontend/src/app/lib/models/remote-user.model.ts
+++ b/prime-angular-frontend/src/app/lib/models/remote-user.model.ts
@@ -7,4 +7,5 @@ export interface RemoteUser {
   email: string;
   remoteUserCertification: RemoteUserCertification;
   notified: boolean;
+  createdDate: string;
 }

--- a/prime-angular-frontend/src/app/modules/site-registration/pages/remote-user-page/remote-user-page.component.html
+++ b/prime-angular-frontend/src/app/modules/site-registration/pages/remote-user-page/remote-user-page.component.html
@@ -68,6 +68,15 @@
 
     </section>
 
+    <app-alert *ngIf="hasDuplicateError"
+               type="danger"
+               icon="warning">
+      <ng-container #alertContent
+                    class="alert-content">
+        Remote User already exists.
+      </ng-container>
+    </app-alert>
+
     <app-page-footer primaryActionLabel="Continue"
                      [hasSecondaryAction]="true"
                      (save)="onSubmit()"

--- a/prime-angular-frontend/src/app/shared/components/site/remote-user-review/remote-user-review.component.html
+++ b/prime-angular-frontend/src/app/shared/components/site/remote-user-review/remote-user-review.component.html
@@ -39,6 +39,12 @@
           {{ remoteUser.remoteUserCertification.practitionerId | default }}
         </app-enrollee-property>
       </div>
+
+      <div class="mb-3">
+        <app-enrollee-property title="Created Date">
+          {{ remoteUser.createdDate | formatDate }}
+        </app-enrollee-property>
+      </div>
     </ng-container>
   </ng-container>
 

--- a/prime-angular-frontend/src/test/mocks/mock-community-site.service.ts
+++ b/prime-angular-frontend/src/test/mocks/mock-community-site.service.ts
@@ -64,7 +64,8 @@ export class MockCommunitySiteService {
             licenseCode: faker.random.number(),
             practitionerId: faker.random.words(5),
           },
-          notified: faker.random.boolean()
+          notified: faker.random.boolean(),
+          createdDate: faker.date.past(2).toDateString(),
         }
       ],
       administratorPharmaNetId: faker.random.number(),

--- a/prime-dotnet-webapi/Models/SiteRegistration/RemoteUser.cs
+++ b/prime-dotnet-webapi/Models/SiteRegistration/RemoteUser.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using DelegateDecompiler;
 using Newtonsoft.Json;
 
 namespace Prime.Models
@@ -29,6 +31,13 @@ namespace Prime.Models
         /// Whether there was an attempt to notify Remote User by email
         /// </summary>
         public bool Notified { get; set; }
+
+        [NotMapped]
+        [Computed]
+        public DateTimeOffset? CreatedDate
+        {
+            get => this.CreatedTimeStamp;
+        }
 
         public RemoteUserCertification RemoteUserCertification { get; set; }
     }

--- a/prime-dotnet-webapi/Services/SiteService.cs
+++ b/prime-dotnet-webapi/Services/SiteService.cs
@@ -273,6 +273,7 @@ namespace Prime.Services
         {
             return await _context.RemoteUsers
                 .Where(user => user.SiteId == siteId)
+                .OrderByDescending(user => user.CreatedDate)
                 .ProjectTo<RemoteUserViewModel>(_mapper.ConfigurationProvider)
                 .ToListAsync();
         }
@@ -294,10 +295,11 @@ namespace Prime.Services
                     (ruc.PractitionerId == searchedCert.PractitionerId && searchedCert.CollegeCode == CollegeCode.BCCNM)));
             }
 
+            // Remote user needs to have been notified when site is approved, sit is not deleted or archived
             IEnumerable<RemoteAccessSearchDto> searchResults = await _context.RemoteUserCertifications
                 .AsNoTracking()
                 .AsExpandable()
-                .Where(ruc => ruc.RemoteUser.Site.ApprovedDate.HasValue &&
+                .Where(ruc => ruc.RemoteUser.Notified &&
                     ruc.RemoteUser.Site.DeletedDate == null && ruc.RemoteUser.Site.ArchivedDate == null)
                 .Where(matchesAnyCert)
                 .ProjectTo<RemoteAccessSearchDto>(_mapper.ConfigurationProvider)


### PR DESCRIPTION
- add validation to avoid duplicate remote user entry in PCHP
- update API to skip duplicate remote user entry
- update the business logic that finds matching remote user from enrolment to use notified flag instead of site approved date. so that when signing authority tries to add more remote user and bring the site o review status, the enrollee is still able to add remote access.
- add the remote user created date in admin page and sort the remote user by created date in descending order   