### PR TITLE
OHID-374 Improve Adjudication Error Message 

### DIFF
--- a/prime-dotnet-webapi/HttpClients/College Licence API/DummyCollegeLicenceClient.cs
+++ b/prime-dotnet-webapi/HttpClients/College Licence API/DummyCollegeLicenceClient.cs
@@ -24,7 +24,7 @@ namespace Prime.HttpClients
                 "3" => new { Date = "1998-08-08", Name = "THREE" },
                 "4" => new { Date = "1999-10-01", Name = "FOUR" },
                 "5" => new { Date = "1999-01-31", Name = "FIVE" },
-                "6" => new { Date = "2000-02-25", Name = "SIX" },
+                "6" => new { Date = "2000-02-25", Name = "SIXX" },
                 "7" => new { Date = "1999-03-14", Name = "SEVEN" },
                 "8" => new { Date = "1999-01-04", Name = "EIGHT" },
                 "9" => new { Date = "1997-10-12", Name = "NINE" },

--- a/prime-dotnet-webapi/Services/Rules/AutomaticAdjudicationRules.cs
+++ b/prime-dotnet-webapi/Services/Rules/AutomaticAdjudicationRules.cs
@@ -190,7 +190,7 @@ namespace Prime.Services.Rules
 
                 if (!record.MatchesEnrolleeByName(enrollee))
                 {
-                    enrollee.AddReasonToCurrentStatus(StatusReasonType.NameDiscrepancy, $"{cert} returned \"{record.FirstName} {record.LastName}\".");
+                    enrollee.AddReasonToCurrentStatus(StatusReasonType.NameDiscrepancy, $"{cert} returned First Name \"{record.FirstName}\" and Last Name \"{record.LastName}\".");
                     passed = false;
                 }
                 if (!_ignoreDOBDiscrepancy && record.DateofBirth.Date != enrollee.DateOfBirth.Date)


### PR DESCRIPTION
Update license name discrepancy error message to separate the first name and the last name so that PRIME Admin can tell which field is not matching and inform the enrollee to update alternative name correctly to pass the rule.  